### PR TITLE
chore(rgy_chapter/get_unicode_data): follow description

### DIFF
--- a/NVEncCore/rgy_chapter.h
+++ b/NVEncCore/rgy_chapter.h
@@ -139,7 +139,7 @@ private:
     void close(); //終了、リソース開放
     int read_file(); //ファイルの読み込み
 
-    //内部のm_code_pageに従って文字データをwcharに変換
+    //内部のm_code_pageに従って文字データをUTF-8に変換
     int get_unicode_data(std::string& data, std::vector<char>& src);
 
     //文字データの文字コードをチェック、判定した文字コードを返す


### PR DESCRIPTION
follow description to 24e85dd953166843b5b77ffad64bc0b6e1a38926

Currently, `wchar_t` is not used.