### PR TITLE
Update --bref-mode documentation in NVEncC_Options.md

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -666,11 +666,10 @@ Specify the AQ strength. (1 (weak) - 15 (strong), 0 = auto)
 
 ### --bref-mode &lt;string&gt;
 Specify B frame reference mode.
-- disabled (default)
-- each
-  use each B frames as references  
-- middle
-  Only(Number of B-frame)/2 th B-frame will be used for reference  
+- auto (default)
+- disabled
+- each ... use each B frames as references  
+- middle ... only (Number of B-frame)/2 th B-frame will be used for reference  
 
 ### --direct &lt;string&gt; [H.264]
 Specify H.264 B Direct mode.

--- a/NVEncC_Options.ja.md
+++ b/NVEncC_Options.ja.md
@@ -671,11 +671,10 @@ AQ強度を指定する。(1(弱) ～ 15(強)、0 = 自動)
 
 ### --bref-mode &lt;string&gt;
 Bフレームの参照モードを指定する。
-- disabled (default)
-- each
-  すべてのBフレームを参照フレームとして利用する  
-- middle
-  偶数番目のBフレームのみが参照フレームとして利用できる  
+- auto (default)
+- disabled
+- each ... すべてのBフレームを参照フレームとして利用する  
+- middle ... 偶数番目のBフレームのみが参照フレームとして利用できる  
 
 ### --direct &lt;string&gt; [H.264]
 H.264のBDirect modeを指定する。


### PR DESCRIPTION
Just a quick fix both NVEncC Options pages regarding `--bref-mode`...

**[Current online Options.EN page](https://github.com/rigaya/NVEnc/blob/master/NVEncC_Options.en.md#--bref-mode-string):**
```
--bref-mode <string>         Specify B frame reference mode.
     - disabled (default)
     - each use each B frames as references
     - middle Only(Number of B-frame)/2 th B-frame will be used for reference
```


**Console help:**
```
   --bref-mode <string>         set B frame reference mode
                                  - auto (default)
                                  - disabled
                                  - each
                                  - middle
```

Source code: 
https://github.com/rigaya/NVEnc/blob/8e5bb3a63d53db8274f9ba7771945fc6c8f30bea/NVEncCore/NVEncParam.h#L343-L349