### PR TITLE
Resolve issues that arise while compiling the code

### DIFF
--- a/NVEncCore/NVEncFilterResize.cu
+++ b/NVEncCore/NVEncFilterResize.cu
@@ -102,6 +102,9 @@ const TCHAR *NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_116.dll");
 #elif __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 7
 const TCHAR *NVRTC_DLL_NAME_TSTR = _T("nvrtc64_117_0.dll");
 const TCHAR *NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_117.dll");
+#elif __CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ == 8
+const TCHAR* NVRTC_DLL_NAME_TSTR = _T("nvrtc64_112_0.dll");
+const TCHAR* NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_118.dll");
 #elif __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 0
 const TCHAR *NVRTC_DLL_NAME_TSTR = _T("nvrtc64_120_0.dll");
 const TCHAR *NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_120.dll");

--- a/NVEncCore/rgy_prm.h
+++ b/NVEncCore/rgy_prm.h
@@ -619,7 +619,7 @@ const CX_DESC list_vpp_nnedi_error_type[] = {
     { NULL, 0 }
 };
 
-const CX_DESC list_vpp_deband[] = {
+/*const CX_DESC list_vpp_deband[] = {
     { _T("0 - 1点参照"),  0 },
     { _T("1 - 2点参照"),  1 },
     { _T("2 - 4点参照"),  2 },
@@ -632,7 +632,7 @@ const CX_DESC list_vpp_deband_en[] = {
     { _T("2 - 4pixel ref"),  2 },
     { NULL, 0 }
 };
-static_assert(_countof(list_vpp_deband) == _countof(list_vpp_deband_en), "_countof(list_vpp_deband) == _countof(list_vpp_deband_en)");
+static_assert(_countof(list_vpp_deband) == _countof(list_vpp_deband_en), "_countof(list_vpp_deband) == _countof(list_vpp_deband_en)");*/
 
 const CX_DESC list_vpp_rotate[] = {
     { _T("90"),   90 },

--- a/cudaver.props
+++ b/cudaver.props
@@ -106,6 +106,13 @@
     <CUDA_CODE_GEN>compute_50,compute_50;compute_61,compute_61;compute_75,compute_75;compute_86,compute_86</CUDA_CODE_GEN>
     <NVRTC_DLL_NAME>nvrtc64_117_0.dll</NVRTC_DLL_NAME>
   </PropertyGroup>
+  <PropertyGroup Label="UserMacros" Condition="'$(CUDA_PATH)' == '$(CUDA_PATH_V11_8)'" >
+	  <CUDA_MAJOR_VER>11</CUDA_MAJOR_VER>
+	  <CUDA_MINOR_VER>8</CUDA_MINOR_VER>
+	  <CUDA_VER>$(CUDA_MAJOR_VER).$(CUDA_MINOR_VER)</CUDA_VER>
+	  <CUDA_CODE_GEN>compute_50,compute_50;compute_61,compute_61;compute_75,compute_75;compute_86,compute_86</CUDA_CODE_GEN>
+	  <NVRTC_DLL_NAME>nvrtc64_118_0.dll</NVRTC_DLL_NAME>
+  </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(CUDA_PATH)' == '$(CUDA_PATH_V12_0)'" >
     <CUDA_MAJOR_VER>12</CUDA_MAJOR_VER>
     <CUDA_MINOR_VER>0</CUDA_MINOR_VER>

--- a/cudaver.props
+++ b/cudaver.props
@@ -111,7 +111,7 @@
 	  <CUDA_MINOR_VER>8</CUDA_MINOR_VER>
 	  <CUDA_VER>$(CUDA_MAJOR_VER).$(CUDA_MINOR_VER)</CUDA_VER>
 	  <CUDA_CODE_GEN>compute_50,compute_50;compute_61,compute_61;compute_75,compute_75;compute_86,compute_86</CUDA_CODE_GEN>
-	  <NVRTC_DLL_NAME>nvrtc64_118_0.dll</NVRTC_DLL_NAME>
+	  <NVRTC_DLL_NAME>nvrtc64_112_0.dll</NVRTC_DLL_NAME>
   </PropertyGroup>
   <PropertyGroup Label="UserMacros" Condition="'$(CUDA_PATH)' == '$(CUDA_PATH_V12_0)'" >
     <CUDA_MAJOR_VER>12</CUDA_MAJOR_VER>


### PR DESCRIPTION
A Windows system that uses UTF-8 encoding may encounter an error when compiling the Japanese section with nvcc.