### PR TITLE
Fix English --lookahead-level description

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -651,7 +651,7 @@ Enable lookahead, and specify its target range by the number of frames. (0 - 32)
 This is useful to improve image quality, allowing adaptive insertion of I and B frames.
 
 ### --lookahead-level &lt;int&gt; [HEVC]
-Set level of lookahead, higher level may improve quality at the expense of performance. (0 - 3, default = auto)  
+Set level of lookahead, higher level may improve quality at the expense of performance. (0 - 3, default: 0 = auto)  
 
 ### --tune &lt;string&gt;
 Set tuning info. Will be changed automatically if ```--lossless```, ```--lowlatecy``` is used.


### PR DESCRIPTION
I can't read Japanese, but it seems to state `0` as the default value, so I guess this should be correct.