### PR TITLE
Fix file input issues in Chinese environment

### DIFF
--- a/NVEncC/NVEncC.cpp
+++ b/NVEncC/NVEncC.cpp
@@ -254,6 +254,11 @@ bool check_locale_is_ja() {
     return GetUserDefaultLangID() == LangID_ja_JP;
 }
 
+bool check_locale_is_chs() {
+	const WORD LangID_zh_CN = MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED);
+	return GetUserDefaultLangID() == LangID_zh_CN;
+}
+
 static tstring getErrorFmtStr(uint32_t err) {
     TCHAR errmes[4097];
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, NULL, errmes, _countof(errmes), NULL);
@@ -367,7 +372,10 @@ int _tmain(int argc, TCHAR **argv) {
 #if defined(_WIN32) || defined(_WIN64)
     if (check_locale_is_ja()) {
         _tsetlocale(LC_ALL, _T("Japanese"));
-    }
+	}
+	else if (check_locale_is_chs()) {
+		_tsetlocale(LC_ALL, _T(".UTF8"));
+	}
 #endif //#if defined(_WIN32) || defined(_WIN64)
 
     if (argc == 1) {

--- a/NVEncCore/NVEncFilterResize.cu
+++ b/NVEncCore/NVEncFilterResize.cu
@@ -117,6 +117,12 @@ const TCHAR *NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_122.dll");
 #elif __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 3
 const TCHAR *NVRTC_DLL_NAME_TSTR = _T("nvrtc64_120_0.dll");
 const TCHAR *NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_123.dll");
+#elif __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 4
+const TCHAR* NVRTC_DLL_NAME_TSTR = _T("nvrtc64_120_0.dll");
+const TCHAR* NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_124.dll");
+#elif __CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 5
+const TCHAR* NVRTC_DLL_NAME_TSTR = _T("nvrtc64_120_0.dll");
+const TCHAR* NVRTC_BUILTIN_DLL_NAME_TSTR = _T("nvrtc-builtins64_125.dll");
 #endif
 #else //#if defined(_WIN32) || defined(_WIN64)
 const TCHAR *NPPI_DLL_NAME_TSTR = _T("libnppc.so");


### PR DESCRIPTION
PS.This is a partial document extracted from msdn:

*   ### UTF-8 support
    Starting in Windows 10 version 1803 (10.0.17134.0), the Universal C Runtime supports using a UTF-8 code page. The change means that char strings passed to C runtime functions can expect strings in the UTF-8 encoding. To enable UTF-8 mode, use ".UTF8" as the code page when using setlocale. For example, setlocale(LC_ALL, ".UTF8") uses the current default Windows ANSI code page (ACP) for the locale and UTF-8 for the code page.

According to the latest documentation, when using _tsetlocal, it is possible to use ". UTF8" instead of specifying a language, which can include all languages and avoid file input exceptions caused by system coding. However, I only have Windows in Chinese and English environments, and I still need to test it in Japanese environments. If ". UTF8" can be used, the following code can be directly changed to:

before:
```
    if (check_locale_is_ja()) {
        _tsetlocale(LC_ALL, _T("Japanese"));
	}
	else if (check_locale_is_chs()) {
		_tsetlocale(LC_ALL, _T(".UTF8"));
	}
```
after:
```
    _tsetlocale(LC_ALL, _T(".UTF8"));
```