### PR TITLE
Fix --vpp-libplacebo-shader documentation

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -2564,7 +2564,7 @@ Apply custom shaders in the specified path using [libplacebo](https://code.video
     - res=&lt;int&gt;x&lt;int&gt;  
       Output resolution of the filter.
 
-    - colorsystem=&lt;int&gt;  
+    - colorsystem=&lt;string&gt;  
       Color system to use. Default: bt709.
       ```
       unknown, bt601, bt709, smpte240m, bt2020nc, bt2020c, bt2100pq, bt2100hlg, dolbyvision, ycgco, rgb, xyz

--- a/NVEncC_Options.ja.md
+++ b/NVEncC_Options.ja.md
@@ -2622,7 +2622,7 @@ nppc64_10.dll, nppif64_10.dll, nppig64_10.dllをNVEncC64と同じフォルダに
     - res=&lt;int&gt;x&lt;int&gt;  
       フィルタの出力解像度。
 
-    - colorsystem=&lt;int&gt;  
+    - colorsystem=&lt;string&gt;  
       使用する色空間を指定。デフォルトはbt709。
       ```
       unknown, bt601, bt709, smpte240m, bt2020nc, bt2020c, bt2100pq, bt2100hlg, dolbyvision, ycgco, rgb, xyz


### PR DESCRIPTION
Because of the listed options and the given default value, I guess this should also be of type `string`.  😅 