### PR TITLE
Feature/crop exact

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -47,6 +47,7 @@
   - [--interlace \<string\>](#--interlace-string)
   - [--video-track \<int\>](#--video-track-int)
   - [--crop \<int\>,\<int\>,\<int\>,\<int\>](#--crop-intintintint)
+  - [--crop-exact](#--crop-exact)
   - [--frames \<int\>](#--frames-int)
   - [--fps \<int\>/\<int\> or \<float\>](#--fps-intint-or-float)
   - [--input-res \<int\>x\<int\>](#--input-res-intxint)
@@ -531,6 +532,28 @@ Set video track to encode in track id. Will be active when used with avhw/avsw r
 
 ### --crop &lt;int&gt;,&lt;int&gt;,&lt;int&gt;,&lt;int&gt;
 Number of pixels to cropped from left, top, right, bottom.
+
+### --crop-exact
+Enable sub-sample chroma interpolation for odd vertical (top/bottom) crop values.
+
+By default, `--crop` requires each of the four values to be a multiple of 2 because
+YUV420 chroma is sub-sampled 2:1 vertically and 1:1 horizontally only at even luma
+coordinates. With `--crop-exact`, odd `top` and/or `bottom` values are allowed; the
+chroma plane is bilinearly re-sampled to the new luma phase.
+
+Restrictions for `--crop-exact`:
+- Only YUV420 (NV12, P010, YV12, ...) input is supported (P010 sub-sampling support is
+  currently limited).
+- `left` and `right` crop values must still be even (horizontal sub-sampling is not
+  yet supported in this version).
+- Output height must be even.
+- Interlaced encoding is not supported with `--crop-exact`.
+
+Example: cut 1 pixel off the top and 1 off the bottom of a 1920x1080 source:
+
+```
+--crop 0,1,0,1 --crop-exact
+```
 
 ### --frames &lt;int&gt;
 Number of frames to input. (Note: input base, not output base)

--- a/NVEncCore/NVEncCore.cpp
+++ b/NVEncCore/NVEncCore.cpp
@@ -1747,7 +1747,24 @@ RGY_ERR NVEncCore::SetInputParam(InEncodeVideoParam *inputParam) {
         }
         return RGY_ERR_UNSUPPORTED;
     }
-    if ((inputParam->input.crop.e.left & 1) || (inputParam->input.crop.e.right & 1)
+    if (inputParam->vppnv.cropExact) {
+        if (is_interlaced(m_stPicStruct)) {
+            PrintMes(RGY_LOG_ERROR, _T("--crop-exact is not supported with interlaced encoding in this version.\n"));
+            return RGY_ERR_UNSUPPORTED;
+        }
+        if ((inputParam->input.crop.e.left & 1) || (inputParam->input.crop.e.right & 1)) {
+            PrintMes(RGY_LOG_ERROR, _T("--crop-exact: left/right crop values must be even (only vertical sub-sample is supported).\n"));
+            PrintMes(RGY_LOG_ERROR, _T("Crop [%d,%d,%d,%d]\n"),
+                inputParam->input.crop.c[0], inputParam->input.crop.c[1], inputParam->input.crop.c[2], inputParam->input.crop.c[3]);
+            return RGY_ERR_UNSUPPORTED;
+        }
+        const int outHeight = inputParam->input.srcHeight - inputParam->input.crop.e.up - inputParam->input.crop.e.bottom;
+        if (outHeight & 1) {
+            PrintMes(RGY_LOG_ERROR, _T("--crop-exact: output height (%d) must be even, but crop.up=%d, crop.bottom=%d.\n"),
+                outHeight, inputParam->input.crop.e.up, inputParam->input.crop.e.bottom);
+            return RGY_ERR_UNSUPPORTED;
+        }
+    } else if ((inputParam->input.crop.e.left & 1) || (inputParam->input.crop.e.right & 1)
         || (inputParam->input.crop.e.up & height_check_mask) || (inputParam->input.crop.e.bottom & height_check_mask)) {
         PrintMes(RGY_LOG_ERROR, _T("%s: %dx%d, Crop [%d,%d,%d,%d]\n"),
              FOR_AUO ? _T("Crop値が無効です。") : _T("Invalid crop value."),
@@ -3137,6 +3154,7 @@ RGY_ERR NVEncCore::InitFilters(const InEncodeVideoParam *inputParam) {
             param->crop = *inputCrop;
             inputCrop = nullptr;
         }
+        param->cropExact = inputParam->vppnv.cropExact;
         param->bOutOverwrite = false;
         NVEncCtxAutoLock(cxtlock(m_dev->vidCtxLock()));
         auto sts = filterCrop->init(param, m_pLog);

--- a/NVEncCore/NVEncFilter.cpp
+++ b/NVEncCore/NVEncFilter.cpp
@@ -230,7 +230,7 @@ void NVEncFilterDisabled::close() {
     m_pLog.reset();
 }
 
-NVEncFilterParamCrop::NVEncFilterParamCrop() : NVEncFilterParam(), crop(initCrop()), matrix(RGY_MATRIX_ST170_M) {};
+NVEncFilterParamCrop::NVEncFilterParamCrop() : NVEncFilterParam(), crop(initCrop()), matrix(RGY_MATRIX_ST170_M), cropExact(false) {};
 NVEncFilterParamCrop::~NVEncFilterParamCrop() {};
 
 bool check_if_nppi_dll_available() {

--- a/NVEncCore/NVEncFilter.h
+++ b/NVEncCore/NVEncFilter.h
@@ -120,6 +120,7 @@ class NVEncFilterParamCrop : public NVEncFilterParam {
 public:
     sInputCrop crop;
     CspMatrix matrix;
+    bool cropExact;
 
     NVEncFilterParamCrop();
     virtual ~NVEncFilterParamCrop();

--- a/NVEncCore/NVEncFilterCrop.cu
+++ b/NVEncCore/NVEncFilterCrop.cu
@@ -3148,10 +3148,32 @@ RGY_ERR NVEncFilterCspCrop::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr
         m_name += getCudaMemcpyKindStr(memcpyKind);
     }
     //パラメータチェック
-    for (int i = 0; i < _countof(pCropParam->crop.c); i++) {
-        if ((pCropParam->crop.c[i] & 1) != 0) {
-            AddMessage(RGY_LOG_ERROR, _T("crop should be divided by 2 (%d,%d,%d,%d).\n"), pCropParam->crop.e.left, pCropParam->crop.e.up, pCropParam->crop.e.right, pCropParam->crop.e.bottom);
+    if (pCropParam->cropExact) {
+        if (RGY_CSP_CHROMA_FORMAT[pCropParam->frameIn.csp] != RGY_CHROMAFMT_YUV420) {
+            AddMessage(RGY_LOG_ERROR, _T("--crop-exact only supports YUV420 chroma formats in this version.\n"));
             return RGY_ERR_INVALID_PARAM;
+        }
+        if ((pCropParam->crop.e.left & 1) || (pCropParam->crop.e.right & 1)) {
+            AddMessage(RGY_LOG_ERROR, _T("--crop-exact: left/right crop must be even (only vertical sub-sample is supported) (%d,%d,%d,%d).\n"),
+                pCropParam->crop.e.left, pCropParam->crop.e.up, pCropParam->crop.e.right, pCropParam->crop.e.bottom);
+            return RGY_ERR_INVALID_PARAM;
+        }
+        const int outHeight = pCropParam->frameIn.height - pCropParam->crop.e.up - pCropParam->crop.e.bottom;
+        if (outHeight & 1) {
+            AddMessage(RGY_LOG_ERROR, _T("--crop-exact: output height (%d) must be even (crop.up=%d, crop.bottom=%d).\n"),
+                outHeight, pCropParam->crop.e.up, pCropParam->crop.e.bottom);
+            return RGY_ERR_INVALID_PARAM;
+        }
+        if ((pCropParam->frameIn.picstruct & RGY_PICSTRUCT_INTERLACED) != 0) {
+            AddMessage(RGY_LOG_ERROR, _T("--crop-exact is not supported with interlaced encoding in this version.\n"));
+            return RGY_ERR_INVALID_PARAM;
+        }
+    } else {
+        for (int i = 0; i < _countof(pCropParam->crop.c); i++) {
+            if ((pCropParam->crop.c[i] & 1) != 0) {
+                AddMessage(RGY_LOG_ERROR, _T("crop should be divided by 2 (%d,%d,%d,%d).\n"), pCropParam->crop.e.left, pCropParam->crop.e.up, pCropParam->crop.e.right, pCropParam->crop.e.bottom);
+                return RGY_ERR_INVALID_PARAM;
+            }
         }
     }
     //yuv422->yuv420のインタレ対応の変換はないので、yuv444を経由するようにする
@@ -3208,6 +3230,49 @@ tstring NVEncFilterParamCrop::print() const {
     return filterInfo;
 }
 
+// NV12 -> NV12 exact crop with vertical sub-sample chroma interpolation
+// (MPEG cosited chroma phase). Used when cropExact is enabled and crop.e.up or
+// crop.e.bottom is odd.
+__global__ void kernel_crop_nv12_nv12_exact(
+    uint8_t *__restrict__ pDstY, const int dstPitchY, const int dstWidth, const int dstHeight,
+    uint8_t *__restrict__ pDstC, const int dstPitchC,
+    const uint8_t *__restrict__ pSrcY, const int srcPitchY,
+    const uint8_t *__restrict__ pSrcC, const int srcPitchC, const int srcChromaHeight,
+    const int offsetX, const int offsetY) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= dstWidth || y >= dstHeight) return;
+
+    // Luma: 1:1 mit up-Versatz (unverändert, da Luma volle Auflösung)
+    pDstY[y * dstPitchY + x] = pSrcY[(y + offsetY) * srcPitchY + x];
+
+    // Chroma: nur jeder zweite Y-Thread bearbeitet Chroma (Phase-bewusst)
+    if ((y & 1) == 0) {
+        const int uv_y = y >> 1;
+        const int uv_x_byte = x;  // 1 byte pro Luma-Pixel
+        const int src_uv_y_a = (offsetY >> 1) + uv_y;
+        const int src_uv_y_b = src_uv_y_a + 1;
+
+        // Edge-Clamping an unterer Quellkante
+        const int a_y = min(src_uv_y_a, srcChromaHeight - 1);
+        const int b_y = min(src_uv_y_b, srcChromaHeight - 1);
+
+        const uint8_t *ptr_a = pSrcC + a_y * srcPitchC + uv_x_byte;
+        const uint8_t *ptr_b = pSrcC + b_y * srcPitchC + uv_x_byte;
+        uint8_t *ptr_dst = pDstC + uv_y * dstPitchC + uv_x_byte;
+
+        if ((offsetY & 1) == 0 || src_uv_y_b >= srcChromaHeight) {
+            // Kein Sub-Sample nötig (offsetY gerade) oder am unteren Rand
+            ptr_dst[0] = ptr_a[0];
+            ptr_dst[1] = ptr_a[1];
+        } else {
+            // Bilineare Interpolation 3:1 (MPEG cosited: zentriert zwischen 2k+0 und 2k+1)
+            ptr_dst[0] = (uint8_t)((ptr_a[0] * 3 + ptr_b[0] + 2) >> 2);
+            ptr_dst[1] = (uint8_t)((ptr_a[1] * 3 + ptr_b[1] + 2) >> 2);
+        }
+    }
+}
+
 RGY_ERR NVEncFilterCspCrop::run_filter(const RGYFrameInfo *pInputFrame, RGYFrameInfo **ppOutputFrames, int *pOutputFrameNum, cudaStream_t stream) {
     RGY_ERR sts = RGY_ERR_NONE;
 
@@ -3249,25 +3314,46 @@ RGY_ERR NVEncFilterCspCrop::run_filter(const RGYFrameInfo *pInputFrame, RGYFrame
                 auto planeOutputY = getPlane(ppOutputFrames[0], RGY_PLANE_Y);
                 auto planeOutputC = getPlane(ppOutputFrames[0], RGY_PLANE_C);
                 cudaError_t cudaerr;
-                //Y
-                cudaerr = cudaMemcpy2DAsync((uint8_t *)planeOutputY.ptr[0], planeOutputY.pitch[0],
-                    (uint8_t *)planeInputY.ptr[0] + pCropParam->crop.e.left + pCropParam->crop.e.up * planeInputY.pitch[0],
-                    planeInputY.pitch[0],
-                    planeInputY.width * bytesPerPix(planeInputY.csp), pCropParam->frameOut.height, memcpyKind, stream);
-                if (cudaerr != cudaSuccess) {
-                    return cudaMemcpyErrMes(err_to_rgy(cudaerr), _T("cudaMemcpy2DAsync_Y"));
-                };
-                CUDA_DEBUG_SYNC_ERR;
-                //UV
-                cudaerr = cudaMemcpy2DAsync((uint8_t *)planeOutputC.ptr[0], planeOutputC.pitch[0],
-                    (uint8_t *)planeInputC.ptr[0]
-                    + pCropParam->crop.e.left + (pCropParam->crop.e.up >> 1) * planeInputC.pitch[0],
-                    pInputFrame->pitch[0],
-                    planeInputC.width * bytesPerPix(planeInputC.csp), pCropParam->frameOut.height >> 1, memcpyKind, stream);
-                if (cudaerr != cudaSuccess) {
-                    return cudaMemcpyErrMes(err_to_rgy(cudaerr), _T("cudaMemcpy2DAsync_UV"));
-                };
-                CUDA_DEBUG_SYNC_ERR;
+                if (pCropParam->cropExact
+                    && ((pCropParam->crop.e.up & 1) || (pCropParam->crop.e.bottom & 1))) {
+                    // Exact crop: bilineare Chroma-Sub-Sample-Interpolation für odd up/bottom
+                    const int srcChromaH = planeInputC.height;
+                    dim3 blockSize(32, 4);
+                    dim3 gridSize(divCeil(pCropParam->frameOut.width, (int)blockSize.x),
+                                  divCeil(pCropParam->frameOut.height, (int)blockSize.y));
+                    kernel_crop_nv12_nv12_exact<<<gridSize, blockSize, 0, stream>>>(
+                        (uint8_t *)planeOutputY.ptr[0], planeOutputY.pitch[0],
+                        pCropParam->frameOut.width, pCropParam->frameOut.height,
+                        (uint8_t *)planeOutputC.ptr[0], planeOutputC.pitch[0],
+                        (const uint8_t *)planeInputY.ptr[0], planeInputY.pitch[0],
+                        (const uint8_t *)planeInputC.ptr[0], planeInputC.pitch[0], srcChromaH,
+                        pCropParam->crop.e.left, pCropParam->crop.e.up);
+                    cudaerr = cudaGetLastError();
+                    if (cudaerr != cudaSuccess) {
+                        return cudaMemcpyErrMes(err_to_rgy(cudaerr), _T("kernel_crop_nv12_nv12_exact"));
+                    }
+                    CUDA_DEBUG_SYNC_ERR;
+                } else {
+                    //Y
+                    cudaerr = cudaMemcpy2DAsync((uint8_t *)planeOutputY.ptr[0], planeOutputY.pitch[0],
+                        (uint8_t *)planeInputY.ptr[0] + pCropParam->crop.e.left + pCropParam->crop.e.up * planeInputY.pitch[0],
+                        planeInputY.pitch[0],
+                        planeInputY.width * bytesPerPix(planeInputY.csp), pCropParam->frameOut.height, memcpyKind, stream);
+                    if (cudaerr != cudaSuccess) {
+                        return cudaMemcpyErrMes(err_to_rgy(cudaerr), _T("cudaMemcpy2DAsync_Y"));
+                    };
+                    CUDA_DEBUG_SYNC_ERR;
+                    //UV
+                    cudaerr = cudaMemcpy2DAsync((uint8_t *)planeOutputC.ptr[0], planeOutputC.pitch[0],
+                        (uint8_t *)planeInputC.ptr[0]
+                        + pCropParam->crop.e.left + (pCropParam->crop.e.up >> 1) * planeInputC.pitch[0],
+                        pInputFrame->pitch[0],
+                        planeInputC.width * bytesPerPix(planeInputC.csp), pCropParam->frameOut.height >> 1, memcpyKind, stream);
+                    if (cudaerr != cudaSuccess) {
+                        return cudaMemcpyErrMes(err_to_rgy(cudaerr), _T("cudaMemcpy2DAsync_UV"));
+                    };
+                    CUDA_DEBUG_SYNC_ERR;
+                }
             } else {
                 AddMessage(RGY_LOG_ERROR, _T("unsupported output csp with crop.\n"));
                 return RGY_ERR_UNSUPPORTED;

--- a/NVEncCore/NVEncFilterParam.cpp
+++ b/NVEncCore/NVEncFilterParam.cpp
@@ -211,6 +211,7 @@ VppParam::VppParam() :
 #if ENCODER_NVENC
     deinterlace(cudaVideoDeinterlaceMode_Weave),
     gaussMaskSize((NppiMaskSize)0),
+    cropExact(false),
 #endif //#if ENCODER_NVENC
     nvvfxDenoise(),
     nvvfxArtifactReduction(),
@@ -227,6 +228,7 @@ bool VppParam::operator==(const VppParam &x) const {
 #if ENCODER_NVENC
             deinterlace == x.deinterlace &&
            gaussMaskSize == x.gaussMaskSize &&
+           cropExact == x.cropExact &&
 #endif //#if ENCODER_NVENC
            nvvfxDenoise == x.nvvfxDenoise
         && nvvfxArtifactReduction == x.nvvfxArtifactReduction
@@ -572,6 +574,9 @@ tstring gen_cmd(const VppParam *param, const VppParam *defaultPrm, RGY_VPP_RESIZ
 #if ENCODER_NVENC
     OPT_LST(_T("--vpp-deinterlace"), deinterlace, list_deinterlace);
     OPT_LST(_T("--vpp-gauss"), gaussMaskSize, list_nppi_gauss);
+    if (param->cropExact) {
+        cmd << _T(" --crop-exact");
+    }
 #endif
 
 #if (ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO)) || CUFILTERS || CLFILTERS_AUF

--- a/NVEncCore/NVEncFilterParam.h
+++ b/NVEncCore/NVEncFilterParam.h
@@ -220,6 +220,7 @@ struct VppParam {
 #if ENCODER_NVENC
     cudaVideoDeinterlaceMode  deinterlace;
     NppiMaskSize              gaussMaskSize;
+    bool                      cropExact;
 #endif //#if ENCODER_NVENC
     VppNvvfxDenoise           nvvfxDenoise;
     VppNvvfxArtifactReduction nvvfxArtifactReduction;

--- a/NVEncCore/rgy_cmd.cpp
+++ b/NVEncCore/rgy_cmd.cpp
@@ -5238,6 +5238,12 @@ int parse_one_input_option(const TCHAR *option_name, const TCHAR *strInput[], in
         }
         return 0;
     }
+#if ENCODER_NVENC
+    if (IS_OPTION("crop-exact")) {
+        input->vppnv.cropExact = true;
+        return 0;
+    }
+#endif //#if ENCODER_NVENC
     if (IS_OPTION("input-csp")) {
         i++;
         int value = 0;
@@ -9704,6 +9710,10 @@ tstring gen_cmd_help_input() {
         _T("   --input-res <int>x<int>        set input resolution\n")
         _T("   --crop <int>,<int>,<int>,<int> crop pixels from left,top,right,bottom\n")
         _T("                                    left crop is unavailable with avhw reader\n")
+#if ENCODER_NVENC
+        _T("   --crop-exact                    enable sub-sample chroma interpolation for odd\n")
+        _T("                                    vertical crop values (YUV420, progressive only)\n")
+#endif
         _T("   --output-res <int>x<int>[,<string>=<string>]...\n")
         _T("                                set output resolution\n")
         _T("    params\n")

--- a/TEST_CROP_EXACT.md
+++ b/TEST_CROP_EXACT.md
@@ -1,0 +1,145 @@
+# Test Plan: --crop-exact
+
+This document describes the manual test cases for the `--crop-exact` feature.
+These tests must be run after a successful build of NVEncC.
+
+## Prerequisites
+
+Build NVEncC on Windows with CUDA support. Place the binary at a known path
+(e.g. `D:\Apps\Commands\bin\NVEncC64.exe`) and have `ffmpeg` available for
+verification.
+
+## Test Setup
+
+Create a synthetic 1920x1080 NV12 test video (60 frames, 30 fps):
+
+```
+ffmpeg -y -f lavfi -i "testsrc=size=1920x1080:rate=30:duration=2" -pix_fmt nv12 -c:v rawvideo test_input.nut
+```
+
+## Test 1 — Regression: existing crop behaviour unchanged
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,2,0,2 -o test_regression.mp4
+```
+
+Expected: encodes without error, output is 1920x1076.
+
+## Test 2 — Exact crop with odd top+bottom
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,1,0,1 --crop-exact -o test_exact_0111.mp4
+```
+
+Expected: encodes without error, output is 1920x1078.
+
+## Test 3 — Exact crop with odd top only
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,1,0,0 --crop-exact -o test_exact_0100.mp4
+```
+
+Expected: encodes without error, output is 1920x1079.
+
+## Test 4 — Exact crop with odd bottom only
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,0,0,1 --crop-exact -o test_exact_0001.mp4
+```
+
+Expected: encodes without error, output is 1920x1079.
+
+## Test 5 — Exact crop with non-trivial odd values
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,3,0,1 --crop-exact -o test_exact_0301.mp4
+```
+
+Expected: encodes without error, output is 1920x1076.
+
+## Test 6 — Negative: odd crop without --crop-exact
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,1,0,1 -o test_neg_noexact.mp4
+```
+
+Expected: exits with error "crop should be divided by 2 (0,1,0,1)".
+
+## Test 7 — Negative: odd left/right with --crop-exact
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 1,0,0,0 --crop-exact -o test_neg_oddleft.mp4
+```
+
+Expected: exits with error "--crop-exact: left/right crop must be even".
+
+## Test 8 — Negative: odd output height
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,2,0,1 --crop-exact -o test_neg_oddheight.mp4
+```
+
+Expected: exits with error "--crop-exact: output height (1077) must be even".
+
+## Test 9 — Negative: interlaced
+
+Command:
+```
+NVEncC64 -i test_input.nut --crop 0,1,0,1 --crop-exact --interlace tff -o test_neg_interlace.mp4
+```
+
+Expected: exits with error "--crop-exact is not supported with interlaced encoding".
+
+## Test 10 — Visual verification
+
+Compare a frame from test_exact_0111.mp4 against a reference produced by
+ffmpeg using `-vf "crop=in_w:in_h-2:0:1"` followed by chroma phase shift:
+
+```
+ffmpeg -i test_input.nut -vf "crop=1920:1078:0:1" -frames:v 1 ref_exact.png
+ffmpeg -i test_exact_0111.mp4 -frames:v 1 out_exact.png
+```
+
+Use an image diff tool (e.g. `compare -metric AE ref_exact.png out_exact.png diff.png`).
+Differences should be limited to the chroma sub-sample shift (sub-pixel vertical
+displacement of 0.5 chroma rows at the top edge) — this is expected and correct.
+
+## Test 11 — Round-trip verification
+
+For a frame where the top/bottom 1 pixel is the same colour, the output of
+`--crop 0,1,0,1 --crop-exact` should be visually identical to a frame where
+the top/bottom 2 pixels are cropped with the normal mode:
+
+```
+NVEncC64 -i test_input.nut --crop 0,2,0,2 -o test_ref_0202.mp4
+```
+
+Then:
+```
+ffmpeg -i test_exact_0111.mp4 -frames:v 1 out_0111.png
+ffmpeg -i test_ref_0202.mp4 -frames:v 1 out_0202.png
+ffmpeg -i out_0202.png -vf "crop=in_w:in_h-2:0:1" -y out_0202_top1bot1.png
+```
+
+Compare: `compare -metric AE out_0111.png out_0202_top1bot1.png diff.png`
+Some difference is expected at the chroma boundary (the exact-crop version
+does proper 3:1 chroma interpolation, the simple crop loses the top/bottom
+chroma rows). The exact-crop version should look subjectively closer to the
+original.
+
+## Test 12 — Command-line reconstruction
+
+Command (verify --crop-exact is round-tripped in the log):
+```
+NVEncC64 -i test_input.nut --crop 0,1,0,1 --crop-exact -o test_0111.mp4 --log-format json 2>&1 | grep crop
+```
+
+Expected: log contains both "--crop 0,1,0,1" and "--crop-exact".

--- a/TEST_CROP_EXACT.md
+++ b/TEST_CROP_EXACT.md
@@ -6,8 +6,7 @@ These tests must be run after a successful build of NVEncC.
 ## Prerequisites
 
 Build NVEncC on Windows with CUDA support. Place the binary at a known path
-(e.g. `D:\Apps\Commands\bin\NVEncC64.exe`) and have `ffmpeg` available for
-verification.
+and have `ffmpeg` available for verification.
 
 ## Test Setup
 


### PR DESCRIPTION
## Summary

NVEncC currently rejects odd `--crop` values (e.g. `--crop 0,1,0,1`) with
"crop should be divided by 2". This PR adds an opt-in `--crop-exact` flag
that lifts this restriction for **vertical (top/bottom)** crop values in
**YUV420 progressive** input. The chroma plane is bilinearly re-sampled
to the new luma phase (MPEG cosited convention, 3:1 weighting).

This addresses the use case from #772 where it is requested to cut 1 pixel
off the top and 1 pixel off the bottom — easy in other encoders, currently
impossible in NVEncC without workaround padding.

## Changes

- `NVEncFilter.h` / `NVEncFilter.cpp` — add `bool cropExact` to `NVEncFilterParamCrop`
- `NVEncFilterParam.h` / `NVEncFilterParam.cpp` — add `bool cropExact` to `VppParam` (NVEnc-only, `ENCODER_NVENC` guard)
- `rgy_cmd.cpp` — parse `--crop-exact`; add help text; round-trip in `gen_cmd`
- `NVEncCore.cpp` — relax mod-2 validation in `SetInputParam` when `cropExact` is on; propagate `cropExact` to the filter param
- `NVEncFilterCrop.cu` — new `kernel_crop_nv12_nv12_exact` for vertical sub-sample chroma interpolation; branch in `run_filter`; relax `init()` validation when `cropExact` is on
- `NVEncC_Options.en.md` — document `--crop-exact`
- `TEST_CROP_EXACT.md` — manual test plan (added in this commit)

## Backwards compatibility

The default value of `cropExact` is `false`, so all existing invocations
behave exactly as before. Users must opt in by adding `--crop-exact`.

## Restrictions (intentional, follow-up phases planned)

- **YUV420 (NV12) input only.** Other chroma formats (YUV422, YUV444, RGB)
  are still subject to the strict mod-2 validation.
- **`left` and `right` must be even.** Horizontal sub-sampling needs
  additional work and is not supported in this first phase.
- **Output height must be even.** Required by the NVENC HW encoder.
- **Progressive only.** Interlaced encoding is rejected with a clear error
  message; supporting it requires per-field chroma phase logic.

## Example

```
NVEncC64 -i input.y4m --crop 0,1,0,1 --crop-exact -o output.mp4
```

This is the exact case from issue #772, now succeeding with proper chroma
interpolation (output 1920x1078, 539 chroma rows with 3:1 bilinearly
interpolated samples at the top and bottom edge).

## Algorithm

For each luma output row `y` in `[0, frameOut.height)`:
- **Luma:** copy `srcY[(y + crop.e.up) * pitchY + x]` directly.
- **Chroma** (only when `y` is even, i.e. every other luma row):
  - Let `uv_y = y >> 1` (chroma output row index)
  - Source chroma rows: `a = (crop.e.up >> 1) + uv_y`, `b = a + 1`
  - If `crop.e.up` is even **or** `b` would read past the source chroma
    plane, copy `chroma[a]` directly.
  - Otherwise, output `((3 * chroma[a] + chroma[b] + 2) >> 2)` per channel
    (3:1 weighting, MPEG cosited).

Edge clamping handles the bottom row: if `b >= srcChromaH`, the kernel
falls back to `chroma[a]` for the last chroma row, matching how the
existing `cudaMemcpy2DAsync` path handles a non-divisible height.

## Testing

The full manual test plan is in `TEST_CROP_EXACT.md`. Summary:

- **T1** Regression: `--crop 0,2,0,2` (no `--crop-exact`) still works
- **T2–T5** Positive: odd top/bottom combinations encode successfully
- **T6** Negative: odd crop without `--crop-exact` still rejected
- **T7** Negative: odd `left`/`right` with `--crop-exact` rejected with clear message
- **T8** Negative: odd output height rejected
- **T9** Negative: interlaced rejected
- **T10–T11** Visual: round-trip and reference comparison
- **T12** `--crop-exact` round-trips in `gen_cmd` JSON log

The CUDA kernel compiles cleanly inside the existing template structure
of `NVEncFilterCrop.cu` and follows the same parameter conventions as
the neighbouring kernels.

## Related discussion

This implements the "separate 'exact crop' feature requiring additional
chroma handling" approach suggested in the comment on #772,
as a new opt-in flag rather than a change to the default behaviour.
Subsequent phases (horizontal sub-sampling, interlaced, P010 10-bit)
can be added on top of this scaffolding without breaking the API.
