### PR TITLE
ngx-vsr: support VFX SDK 1.2 nvngx_vsr.dll quality modes 8-19

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -3408,8 +3408,13 @@ Specify the resizing algorithm.
 
       - Additional parameters
         - vsr-quality=&lt;int&gt;  
-          quality for ngx-vsr (1 - 4, default=1)
+          quality for ngx-vsr (1 - 4 or 8 - 19, default=1)
           larger value results higher quality.
+          - 1 - 4 ... VSR quality levels
+          - 8 - 11 ... denoise
+          - 12 - 15 ... deblur
+          - 16 - 19 ... high-bitrate detail restoration (requires nvngx_vsr.dll from VFX SDK 1.2 or later)
+          modes 8 - 15 do not resize the frame, and require the output resolution to be the same as the input.
       
     - [libplacebo](https://code.videolan.org/videolan/libplacebo) library resize filters
 

--- a/NVEncC_Options.ja.md
+++ b/NVEncC_Options.ja.md
@@ -3465,8 +3465,13 @@ nppc64_11.dll, nppif64_11.dll, nppig64_11.dllをNVEncC64と同じフォルダに
 
       - 追加パラメータ
         - vsr-quality=&lt;int&gt;  
-          ngx-vsr使用時の品質の設定。 (デフォルト=1, 1 - 4)
+          ngx-vsr使用時の品質の設定。 (デフォルト=1, 1 - 4 または 8 - 19)
           数字が大きいほど高品質。
+          - 1 - 4 ... VSR 品質レベル
+          - 8 - 11 ... デノイズ
+          - 12 - 15 ... デブラー (ブラー除去)
+          - 16 - 19 ... 高ビットレート向けのディテール復元 (VFX SDK 1.2 以降の nvngx_vsr.dll が必要)
+          モード 8 - 15 は解像度を変更しないので、出力解像度を入力解像度と同じにする必要がある。
 
     - [libplacebo](https://code.videolan.org/videolan/libplacebo)ライブラリのリサイズフィルタ
     

--- a/NVEncCore/NVEncCore.cpp
+++ b/NVEncCore/NVEncCore.cpp
@@ -3194,8 +3194,16 @@ RGY_ERR NVEncCore::InitFilters(const InEncodeVideoParam *inputParam) {
         }
     }
     RGY_VPP_RESIZE_TYPE resizeRequired = RGY_VPP_RESIZE_TYPE_NONE;
+    // ngx-vsr quality 8-15 (denoise/deblur) from VFX SDK 1.2 nvngx_vsr.dll
+    // run at input=output resolution; the resize filter must be created even
+    // when no resize is requested (requires an explicit --output-res matching
+    // the input resolution). 16-19 (high-bitrate) are upscalers like 1-4 and
+    // follow the normal resize rules.
+    const bool ngxVsrSameRes = inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NGX_VSR
+        && inputParam->vppnv.ngxVSR.quality >= 8
+        && inputParam->vppnv.ngxVSR.quality <= 15;
     if ((resizeWidth > 0 && resizeHeight > 0) &&
-        (croppedWidth != resizeWidth || croppedHeight != resizeHeight)) {
+        (croppedWidth != resizeWidth || croppedHeight != resizeHeight || ngxVsrSameRes)) {
         resizeRequired = getVppResizeType(inputParam->vpp.resize_algo);
         if (resizeRequired == RGY_VPP_RESIZE_TYPE_UNKNOWN) {
             PrintMes(RGY_LOG_ERROR, _T("Unknown resize type.\n"));

--- a/NVEncCore/NVEncFilterNGX.cpp
+++ b/NVEncCore/NVEncFilterNGX.cpp
@@ -508,8 +508,12 @@ RGY_ERR NVEncFilterNGXVSR::checkParam(const NVEncFilterParam *param) {
         AddMessage(RGY_LOG_ERROR, _T("Invalid parameter type.\n"));
         return RGY_ERR_INVALID_PARAM;
     }
-    if (prm->ngxvsr.quality < 1 || 4 < prm->ngxvsr.quality) {
-        AddMessage(RGY_LOG_ERROR, _T("Invalid quality value %d, must be in the range of 1 to 4.\n"), prm->ngxvsr.quality);
+    // quality 1-4: legacy NGX VSR levels.
+    // quality 8-19: VFX SDK 1.2 nvngx_vsr.dll extension
+    // (8-11 = denoise, 12-15 = deblur, 16-19 = high-bitrate detail restoration).
+    if (prm->ngxvsr.quality < 1 || 19 < prm->ngxvsr.quality
+        || (5 <= prm->ngxvsr.quality && prm->ngxvsr.quality < 8)) {
+        AddMessage(RGY_LOG_ERROR, _T("Invalid quality value %d, must be in the range of 1 to 4 or 8 to 19.\n"), prm->ngxvsr.quality);
         return RGY_ERR_INVALID_PARAM;
     }
     return RGY_ERR_NONE;

--- a/NVEncCore/NVEncFilterResize.cu
+++ b/NVEncCore/NVEncFilterResize.cu
@@ -1435,6 +1435,13 @@ RGY_ERR NVEncFilterResize::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr<
         pResizeParam->nvvfxSuperRes.reset();
     }
     if (isNgxResizeFiter(pResizeParam->interp)) {
+        if (pResizeParam->ngxvsr->ngxvsr.quality >= 8 && pResizeParam->ngxvsr->ngxvsr.quality <= 15
+            && (pResizeParam->frameIn.width != pResizeParam->frameOut.width
+                || pResizeParam->frameIn.height != pResizeParam->frameOut.height)) {
+            AddMessage(RGY_LOG_ERROR, _T("ngx-vsr quality 8-15 (denoise/deblur) do not support resizing.\n")
+                _T("Please set --output-res to the same resolution as the input.\n"));
+            return RGY_ERR_UNSUPPORTED;
+        }
         if (!m_ngxVSR) {
             m_ngxVSR = std::make_unique<NVEncFilterNGXVSR>();
         }

--- a/NVEncCore/rgy_cmd.cpp
+++ b/NVEncCore/rgy_cmd.cpp
@@ -17554,7 +17554,9 @@ tstring gen_cmd_help_vpp() {
 #if ENABLE_NVSDKNGX
             str += strsprintf(_T("\n")
                 _T("      vsr-quality=<int>\n")
-                _T("        quality for ngx-vsr\n"));
+                _T("        quality for ngx-vsr (1 - 4 or 8 - 19, default = 1)\n")
+                _T("        8-11 = denoise, 12-15 = deblur, 16-19 = high-bitrate detail restoration\n")
+                _T("        modes 8-19 require nvngx_vsr.dll from VFX SDK 1.2 or later\n"));
 #endif
 #if ENCODER_QSV
             str += strsprintf(_T("\n")


### PR DESCRIPTION
## Summary
The `nvngx_vsr.dll` runtime bundled with **NVIDIA MAXINE Video Effects SDK 1.2** introduces new processing modes beyond the legacy quality levels `1 - 4`:

- **`8 - 11`**: Denoise (Low / Medium / High / Ultra)
- **`12 - 15`**: Deblur (Low / Medium / High / Ultra)
- **`16 - 19`**: High-bitrate detail restoration (Low / Medium / High / Ultra)

*Reference: [NVIDIA Maxine Video Effects SDK Documentation - Video Super Resolution](https://docs.nvidia.com/maxine/vfx/latest/Filters/VideoSuperResolution.html)*

## Key Changes
- **`NVEncFilterNGX.cpp`**: 
  - Extend valid `vsr-quality` range to `1 - 4` and `8 - 19`.
  - Reject invalid/undocumented values (quality `0` and `5 - 7`) with an explicit parameter error.
  - Enforce that modes `8 - 15` run only when output resolution matches input resolution (scaling is unsupported in denoise/deblur modes per SDK specs).
- **`NVEncCore.cpp`**: 
  - Allow the NGX VSR filter to instantiate even when input resolution equals output resolution (enabling standalone 1:1 denoise/deblur without requiring a scale factor).
- **`rgy_cmd.cpp` & Documentation**: 
  - Update CLI `--help` text and option Markdown documents (`NVEncC_Options.*.md`) to reflect the supported quality modes and constraints.

## Runtime & Compatibility Notes (`nvngx_vsr.dll` from VFX SDK 1.2)
- **Drop-in Replacement**: Fully backward-compatible. Quality modes `1 - 4` produce identical bitstreams compared to earlier DLL versions (verified by frame-by-frame comparison).
- **Standalone Usage**: Operates standalone without installing the full Maxine SDK / Models installer. Placing `nvngx_vsr.dll` alongside `NVEncC64.exe` is sufficient.
- **Resolution Support**: Unlike the legacy `NVVFX` SuperResolution path (clamped to 3840×2160 input), the NGX pipeline supports non-standard and large resolutions (verified with a 2560×4608 portrait stream).
- **Backward Compatibility**: dll obtained from rtx video sdk and Pre-1.2 DLLs fail gracefully during NGX effect initialization with the standard NGX error code.

## Verification & Testing
- **Environment**: NVIDIA GeForce RTX 2080 (Turing), VFX SDK 1.2.0.0 (`nvngx_vsr.dll`).
- **Tests**:
  - `quality=8` (1:1 Denoise): Processed and encoded successfully at native resolution.
  - `quality=16` (2× High-bitrate Upscale): Scaled and encoded properly.
  - `quality=5 - 7` (Invalid ranges): Immediately caught and rejected with clear error messages.
  - `quality=1 - 4` (Legacy VSR): Verified identical output against dll obtained from rtx video sdk.

## Related PR
- Related: `nvvfx-videosuperres` filter PR (VFX SDK 1.2 exposes identical processing modes via the NVVFX API path).

### Obtaining the 1.2 nvngx_vsr.dll for testing

The dll ships with the VFX SDK 1.2 installer (https://catalog.ngc.nvidia.com/orgs/nvidia/maxine/collections/nvvfxvideosuperres).
For a quick test without installing the SDK, NVIDIA also publishes it in their
public Python package index; the dll can be extracted from the wheel below
(path inside the archive: `nvvfx/libs/nvngx_vsr.dll`, ~45 MB, just open the .whl file in unzip software like winrar):

https://pypi.nvidia.com/nvidia-vfx/nvidia_vfx-0.1.0.1-cp312-abi3-win_amd64.whl

SHA-256 of the extracted dll:
`dcd47a599d3ec250ca4f9c70e14cd7475e2fefb7f1c3dc81a0ca6490b32a1458`

Place it next to NVEncC64.exe, as with the current ngx-vsr dll. (Version-pinned
link as of this writing — NVIDIA may re-publish newer versions at the same index.)
