### PR TITLE
Nvvfx videosuperres

### DIFF
--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -3404,8 +3404,7 @@ Specify the resizing algorithm.
 
       - Additional parameters
         - videosuperres-quality=&lt;int&gt;  
-          quality for nvvfx-videosuperres (0 - 19, except 5 - 7, default = 1)
-          - 0 ... bicubic
+          quality for nvvfx-videosuperres (1 - 19, except 5 - 7, default = 1)
           - 1 - 4 ... superres (Low / Medium / High / Ultra)
           - 8 - 11 ... denoise
           - 12 - 15 ... deblur

--- a/NVEncC_Options.en.md
+++ b/NVEncC_Options.en.md
@@ -3385,6 +3385,7 @@ Specify the resizing algorithm.
       | name | description |
       |:---|:---|
       | nvvfx-superres | Super Resolution based on nvvfx library (upscale only)     |
+      | nvvfx-videosuperres | Video Super Resolution based on nvvfx library (VFX SDK 1.2) |
 
       ```nvvfx-superres``` is super resolution filter from [NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK), which is supported on  x64 version only.
       This mode is supported on Turing Gen GPU (RTX20xx) or later. Please download and install [Video Effect models and runtime dependencies](https://www.nvidia.com/broadcast-sdk-resources) to use this mode.
@@ -3397,6 +3398,20 @@ Specify the resizing algorithm.
       
         - superres-strength=&lt;float&gt;  
           strength for nvvfx-superres (0.0 - 1.0, default = 0.4)
+
+      ```nvvfx-videosuperres``` is the Video Super Resolution filter added in [NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK) 1.2, supported on x64 version only.
+      This mode is supported on Turing Gen GPU (RTX20xx) or later. Please download and install [Video Effect models and runtime dependencies](https://www.nvidia.com/broadcast-sdk-resources) to use this mode.
+
+      - Additional parameters
+        - videosuperres-quality=&lt;int&gt;  
+          quality for nvvfx-videosuperres (0 - 19, except 5 - 7, default = 1)
+          - 0 ... bicubic
+          - 1 - 4 ... superres (Low / Medium / High / Ultra)
+          - 8 - 11 ... denoise
+          - 12 - 15 ... deblur
+          - 16 - 19 ... high-bitrate detail restoration (VFX SDK 1.2 or later)
+          modes 8 - 15 do not resize the frame, and require the output resolution to be the same as the input.
+          modes 1 - 4 and 16 - 19 support upscaling.
 
     - [NGX](https://docs.nvidia.com/rtx/ngx/programming-guide/index.html) library resize filters
 
@@ -3471,6 +3486,9 @@ Specify the resizing algorithm.
 
   Examples: Use nvvfx-superres in mode 1
   --vpp-resize algo=nvvfx-superres,superres-mode=1
+
+  Examples: Use nvvfx-videosuperres (VFX SDK 1.2, quality 16)
+  --vpp-resize algo=nvvfx-videosuperres,videosuperres-quality=16
 
   Examples: Use ngx-vsr in best quality
   --vpp-resize algo=ngx-vsr,vsr-quality=4

--- a/NVEncC_Options.ja.md
+++ b/NVEncC_Options.ja.md
@@ -3441,6 +3441,7 @@ nppc64_11.dll, nppif64_11.dll, nppig64_11.dllをNVEncC64と同じフォルダに
       | 名前 | 説明 |
       |:---|:---|
       | nvvfx-superres | NVIDIA Video EffectsによるSuper Resolution (拡大のみ)  |  |
+      | nvvfx-videosuperres | NVIDIA Video Effects (VFX SDK 1.2)によるVideo Super Resolution  |  |
 
       このモードは、[NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK)によるAIによって拡大処理を行うので、実行にはx64版の実行ファイルとTuring世代(RTX20xx)以降のGPUが必要。また、あわせて[MAXINE VideoEffects 用のモデルと実行モジュール](https://www.nvidia.com/broadcast-sdk-resources)をダウンロード・インストールしてからお使いください。
 
@@ -3454,6 +3455,19 @@ nppc64_11.dll, nppif64_11.dll, nppig64_11.dllをNVEncC64と同じフォルダに
       
         - superres-strength=&lt;float&gt;  
           nvvfx-superresの強さの指定。 (0.0 - 1.0, デフォルト = 0.4)
+
+      ```nvvfx-videosuperres```は、[NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK) 1.2で追加されたVideo Super Resolutionフィルタ。実行にはx64版の実行ファイルとTuring世代(RTX20xx)以降のGPUが必要。また、あわせて[MAXINE VideoEffects 用のモデルと実行モジュール](https://www.nvidia.com/broadcast-sdk-resources)をダウンロード・インストールしてからお使いください。
+
+      - 追加パラメータ
+        - videosuperres-quality=&lt;int&gt;  
+          nvvfx-videosuperres の品質の設定。 (0 - 19 (5 - 7 を除く), デフォルト = 1)
+          - 0 ... バイキュービック
+          - 1 - 4 ... superres (Low / Medium / High / Ultra)
+          - 8 - 11 ... デノイズ
+          - 12 - 15 ... デブラー (ブラー除去)
+          - 16 - 19 ... 高ビットレート向けのディテール復元 (VFX SDK 1.2 以降が必要)
+          モード 8 - 15 は解像度を変更しないので、出力解像度を入力解像度と同じにする必要がある。
+          モード 1 - 4 と 16 - 19 は拡大に対応している。
 
     - [NGX](https://docs.nvidia.com/rtx/ngx/programming-guide/index.html)ライブラリのリサイズフィルタ
   
@@ -3528,6 +3542,9 @@ nppc64_11.dll, nppif64_11.dll, nppig64_11.dllをNVEncC64と同じフォルダに
 
   例: nvvfx-superresを効果強めで使用する
   --vpp-resize algo=nvvfx-superres,superres-mode=1
+
+  例: nvvfx-videosuperresを使用する (VFX SDK 1.2, quality 16)
+  --vpp-resize algo=nvvfx-videosuperres,videosuperres-quality=16
 
   例: ngx-vsrを最高品質で使用する
   --vpp-resize algo=ngx-vsr,vsr-quality=4

--- a/NVEncC_Options.ja.md
+++ b/NVEncC_Options.ja.md
@@ -3460,8 +3460,7 @@ nppc64_11.dll, nppif64_11.dll, nppig64_11.dllをNVEncC64と同じフォルダに
 
       - 追加パラメータ
         - videosuperres-quality=&lt;int&gt;  
-          nvvfx-videosuperres の品質の設定。 (0 - 19 (5 - 7 を除く), デフォルト = 1)
-          - 0 ... バイキュービック
+          nvvfx-videosuperres の品質の設定。 (1 - 19 (5 - 7 を除く), デフォルト = 1)
           - 1 - 4 ... superres (Low / Medium / High / Ultra)
           - 8 - 11 ... デノイズ
           - 12 - 15 ... デブラー (ブラー除去)

--- a/NVEncC_Options.zh-cn.md
+++ b/NVEncC_Options.zh-cn.md
@@ -2450,8 +2450,7 @@ npp dll可以在[这里](https://github.com/rigaya/NVEnc/releases/tag/7.00) (npp
   - superres-strength=&lt;float&gt;  
     nvvfx-superres的强度(0.0 - 1.0, default = 0.4)
   - videosuperres-quality=&lt;int&gt;  
-    nvvfx-videosuperres的品质(0 - 19, 除去5 - 7, default = 1)
-    - 0 ... 双三次插值
+    nvvfx-videosuperres的品质(1 - 19, 除去5 - 7, default = 1)
     - 1 - 4 ... superres (Low / Medium / High / Ultra)
     - 8 - 11 ... 降噪
     - 12 - 15 ... 去模糊 (deblur)

--- a/NVEncC_Options.zh-cn.md
+++ b/NVEncC_Options.zh-cn.md
@@ -2441,6 +2441,7 @@ npp dll可以在[这里](https://github.com/rigaya/NVEnc/releases/tag/7.00) (npp
     | super         | NPP 库提供的所谓的 "super sampling"  | ○ |
     | lanczos       | Lanczos 插值                    | ○ |
     | nvvfx-superres | 基于nvvfx库的超分辨率(仅适用于放大) |   |
+    | nvvfx-videosuperres | 基于nvvfx库的视频超分辨率 (VFX SDK 1.2) |   |
 
   - superres-mode=&lt;int&gt;  
     选择nvvfx-superres的模式
@@ -2448,12 +2449,23 @@ npp dll可以在[这里](https://github.com/rigaya/NVEnc/releases/tag/7.00) (npp
     - 1 ... 激进 (default)
   - superres-strength=&lt;float&gt;  
     nvvfx-superres的强度(0.0 - 1.0, default = 0.4)
+  - videosuperres-quality=&lt;int&gt;  
+    nvvfx-videosuperres的品质(0 - 19, 除去5 - 7, default = 1)
+    - 0 ... 双三次插值
+    - 1 - 4 ... superres (Low / Medium / High / Ultra)
+    - 8 - 11 ... 降噪
+    - 12 - 15 ... 去模糊 (deblur)
+    - 16 - 19 ... 高码率细节恢复 (需要 VFX SDK 1.2 或更新版本)
+    模式 8 - 15 不改变分辨率，输出分辨率需要与输入相同。
+    模式 1 - 4 与 16 - 19 支持放大。
 
 - 注意事项
   - 标记为"○"的算法需要[NPP library](https://developer.nvidia.com/npp)，仅在 x64 版本支持。要使用这些算法，需要另外下载 nppc64_10.dll, nppif64_10.dll, nppig64_10.dll并把它和 NVEncC64.exe 放置在同一目录。
     这些npp dll可以在[这里](https://github.com/rigaya/NVEnc/releases/tag/7.00) (npp64_10_dll_7zip.7z)下载。
   - ```nvvfx-superres``` 是来自[NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK)的超分辨率过滤器, 仅在x64版本支持。
     这一模式支持 Turing 架构(RTX20xx)及更新的显卡，如果要使用这一模式，需要下载并安装 [Video Effect models and runtime dependencies](https://www.nvidia.com/broadcast-sdk-resources).
+  - ```nvvfx-videosuperres``` 是 [NVIDIA MAXINE VideoEffects SDK](https://github.com/NVIDIA/MAXINE-VFX-SDK) 1.2 新增的视频超分辨率过滤器, 仅在x64版本支持。
+    这一模式支持 Turing 架构(RTX20xx)及更新的显卡，使用 quality 8 - 19 时需要 VFX SDK 1.2 或更新版本的运行时。
 
 
 ```
@@ -2465,6 +2477,9 @@ npp dll可以在[这里](https://github.com/rigaya/NVEnc/releases/tag/7.00) (npp
 
 例子: 使用 nvvfx-superres, 模式为激进
 --vpp-resize algo=nvvfx-superres,superres-mode=1
+
+例子: 使用 nvvfx-videosuperres (VFX SDK 1.2, quality 16)
+--vpp-resize algo=nvvfx-videosuperres,videosuperres-quality=16
   ```
 ### --vpp-unsharp [&lt;param1&gt;=&lt;value1&gt;][,&lt;param2&gt;=&lt;value2&gt;],...
 反锐化滤镜，用于边缘和细节增强。

--- a/NVEncCore/NVEncCore.cpp
+++ b/NVEncCore/NVEncCore.cpp
@@ -960,7 +960,8 @@ bool NVEncCore::useNVVFX(const InEncodeVideoParam *inputParam) const {
         || vppnv.nvvfxDenoise.enable
         || vppnv.nvvfxSuperRes.enable
         || vppnv.nvvfxUpScaler.enable
-        || inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NVVFX_SUPER_RES) {
+        || inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NVVFX_SUPER_RES
+        || inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES) {
         return true;
     }
 #endif
@@ -3194,8 +3195,16 @@ RGY_ERR NVEncCore::InitFilters(const InEncodeVideoParam *inputParam) {
         }
     }
     RGY_VPP_RESIZE_TYPE resizeRequired = RGY_VPP_RESIZE_TYPE_NONE;
+    // nvvfx-videosuperres quality 8-15 (denoise/deblur) require the
+    // effect to run at input=output resolution, so the resize filter must be
+    // created even when no resize is requested (requires an explicit
+    // --output-res matching the input resolution). 16-19 (high-bitrate) are
+    // upscalers like 1-4 and follow the normal resize rules.
+    const bool nvvfxVideoSuperResSameRes = inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES
+        && inputParam->vppnv.nvvfxVideoSuperRes.quality >= 8
+        && inputParam->vppnv.nvvfxVideoSuperRes.quality <= 15;
     if ((resizeWidth > 0 && resizeHeight > 0) &&
-        (croppedWidth != resizeWidth || croppedHeight != resizeHeight)) {
+        (croppedWidth != resizeWidth || croppedHeight != resizeHeight || nvvfxVideoSuperResSameRes)) {
         resizeRequired = getVppResizeType(inputParam->vpp.resize_algo);
         if (resizeRequired == RGY_VPP_RESIZE_TYPE_UNKNOWN) {
             PrintMes(RGY_LOG_ERROR, _T("Unknown resize type.\n"));
@@ -4660,7 +4669,13 @@ RGY_ERR NVEncCore::AddFilterCUDA(std::vector<std::unique_ptr<NVEncFilter>>& cufi
         param->dpid = inputParam->vpp.resize_dpid;
         param->nis = inputParam->vpp.resize_nis;
         param->bicubic = inputParam->vpp.resize_bicubic;
-        if (isNvvfxResizeFiter(inputParam->vpp.resize_algo)) {
+        if (inputParam->vpp.resize_algo == RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES) {
+            param->nvvfxVideoSuperRes = std::make_shared<NVEncFilterParamNvvfxVideoSuperRes>();
+            param->nvvfxVideoSuperRes->nvvfxVideoSuperRes = inputParam->vppnv.nvvfxVideoSuperRes;
+            param->nvvfxVideoSuperRes->compute_capability = m_dev->cc();
+            param->nvvfxVideoSuperRes->modelDir = inputParam->vppnv.nvvfxModelDir;
+            param->nvvfxVideoSuperRes->vuiInfo = vuiInfo;
+        } else if (isNvvfxResizeFiter(inputParam->vpp.resize_algo)) {
             param->nvvfxSuperRes = std::make_shared<NVEncFilterParamNvvfxSuperRes>();
             param->nvvfxSuperRes->nvvfxSuperRes = inputParam->vppnv.nvvfxSuperRes;
             param->nvvfxSuperRes->compute_capability = m_dev->cc();

--- a/NVEncCore/NVEncFilter.h
+++ b/NVEncCore/NVEncFilter.h
@@ -150,6 +150,7 @@ protected:
 };
 
 class NVEncFilterParamNvvfxSuperRes;
+class NVEncFilterParamNvvfxVideoSuperRes;
 class NVEncFilterParamNGXVSR;
 class NVEncFilterParamLibplaceboResample;
 class DeviceDX11;
@@ -163,6 +164,7 @@ public:
     VppResizeNis nis;
     VppResizeBicubic bicubic;
     std::shared_ptr<NVEncFilterParamNvvfxSuperRes> nvvfxSuperRes;
+    std::shared_ptr<NVEncFilterParamNvvfxVideoSuperRes> nvvfxVideoSuperRes;
     std::shared_ptr<NVEncFilterParamNGXVSR> ngxvsr;
     std::shared_ptr<NVEncFilterParamLibplaceboResample> libplaceboResample;
     NVEncFilterParamResize();
@@ -171,6 +173,7 @@ public:
 };
 
 class NVEncFilterNvvfxSuperRes;
+class NVEncFilterNvvfxVideoSuperRes;
 class NVEncFilterNGXVSR;
 class NVEncFilterLibplaceboResample;
 
@@ -184,6 +187,7 @@ protected:
     RGY_ERR resizeNppi(RGYFrameInfo *pOutputFrame, const RGYFrameInfo *pInputFrame, cudaStream_t stream);
     RGY_ERR resizeNppiYUV444(RGYFrameInfo *pOutputFrame, const RGYFrameInfo *pInputFrame, cudaStream_t stream);
     RGY_ERR initNvvfxFilter(NVEncFilterParamResize *param);
+    RGY_ERR initNvvfxVideoSuperResFilter(NVEncFilterParamResize *param);
     RGY_ERR resizeNvvfxSuperRes(RGYFrameInfo *pOutputFrame, const RGYFrameInfo *pInputFrame);
     virtual void close() override;
 
@@ -198,6 +202,7 @@ protected:
     int m_nisStages;                               // NIS cascade stage count (1 for <=2x, N for larger ratios)
     std::vector<std::unique_ptr<CUFrameBuf>> m_nisCascadeInter; // NIS cascade intermediate frames (stages-1)
     std::unique_ptr<NVEncFilterNvvfxSuperRes> m_nvvfxSuperRes;
+    std::unique_ptr<NVEncFilterNvvfxVideoSuperRes> m_nvvfxVideoSuperRes;
     std::unique_ptr<NVEncFilterNGXVSR> m_ngxVSR;
     std::unique_ptr<NVEncFilterLibplaceboResample> m_libplaceboResample;
 };

--- a/NVEncCore/NVEncFilterNvvfx.cpp
+++ b/NVEncCore/NVEncFilterNvvfx.cpp
@@ -184,7 +184,10 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
     // while pre-1.2 runtimes (0.7.x) only accept the legacy BGR F32 planar
     // layout. Pick the buffer format by the loaded runtime version so that
     // behavior on older runtimes stays identical to the legacy format.
-    {
+    // (Only VideoSuperRes is affected by the runtime version; the legacy
+    // nvvfx effects always use their own buffer format regardless.)
+    if (const auto prmVsr = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(pParam.get());
+        prmVsr != nullptr) {
         uint32_t vfxVersion = 0;
         if (err_to_rgy(NvVFX_GetVersion(&vfxVersion)) == RGY_ERR_NONE
             && vfxVersion >= ((1u << 24) | (2u << 16))) {
@@ -194,8 +197,7 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
             m_bgraU8 = false;
             AddMessage(RGY_LOG_WARN, _T("nvvfx runtime version %d.%d does not support RGBA U8 buffers (requires 1.2+), using legacy BGR F32 planar buffers.\n"),
                 (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
-            if (auto prmVsr = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(pParam.get());
-                prmVsr != nullptr && prmVsr->nvvfxVideoSuperRes.quality >= 8) {
+            if (prmVsr->nvvfxVideoSuperRes.quality >= 8) {
                 AddMessage(RGY_LOG_ERROR, _T("quality 8-19 requires VFX SDK 1.2 or later, but the loaded nvvfx runtime is %d.%d. Please install or update the NVIDIA Video Effects runtime, or use quality 1-4.\n"),
                     (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
                 return RGY_ERR_UNSUPPORTED;

--- a/NVEncCore/NVEncFilterNvvfx.cpp
+++ b/NVEncCore/NVEncFilterNvvfx.cpp
@@ -196,7 +196,7 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
                 (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
             if (auto prmVsr = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(pParam.get());
                 prmVsr != nullptr && prmVsr->nvvfxVideoSuperRes.quality >= 8) {
-                AddMessage(RGY_LOG_ERROR, _T("quality 8-19 requires VFX SDK 1.2 or later, but the loaded nvvfx runtime is %d.%d. Please install or update the NVIDIA Video Effects runtime, or use quality 0-4.\n"),
+                AddMessage(RGY_LOG_ERROR, _T("quality 8-19 requires VFX SDK 1.2 or later, but the loaded nvvfx runtime is %d.%d. Please install or update the NVIDIA Video Effects runtime, or use quality 1-4.\n"),
                     (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
                 return RGY_ERR_UNSUPPORTED;
             }
@@ -805,13 +805,13 @@ RGY_ERR NVEncFilterNvvfxVideoSuperRes::checkParam(const NVEncFilterParam *param)
         AddMessage(RGY_LOG_ERROR, _T("Invalid parameter type.\n"));
         return RGY_ERR_INVALID_PARAM;
     }
-    // quality 0 = bicubic, 1-4 = superres (Low/Medium/High/Ultra),
+    // quality 1-4 = superres (Low/Medium/High/Ultra),
     // 8-11 = denoise, 12-15 = deblur, 16-19 = high-bitrate detail restoration (VFX SDK 1.2+).
     // Only modes 8-15 require input=output resolution (per VFX 1.2 docs);
     // 1-4 and 16-19 are upscalers and support resizing.
-    if (prm->nvvfxVideoSuperRes.quality < 0 || 19 < prm->nvvfxVideoSuperRes.quality
+    if (prm->nvvfxVideoSuperRes.quality < 1 || 19 < prm->nvvfxVideoSuperRes.quality
         || (5 <= prm->nvvfxVideoSuperRes.quality && prm->nvvfxVideoSuperRes.quality < 8)) {
-        AddMessage(RGY_LOG_ERROR, _T("quality should be 0 - 19 (except 5-7).\n"));
+        AddMessage(RGY_LOG_ERROR, _T("quality should be 1 - 19 (except 5-7).\n"));
         return RGY_ERR_INVALID_PARAM;
     }
     return RGY_ERR_NONE;

--- a/NVEncCore/NVEncFilterNvvfx.cpp
+++ b/NVEncCore/NVEncFilterNvvfx.cpp
@@ -45,6 +45,7 @@ NVEncFilterNvvfxEffect::NVEncFilterNvvfxEffect() :
     m_effectName(),
     m_maxWidth(std::numeric_limits<decltype(m_maxWidth)>::max()),
     m_maxHeight(std::numeric_limits<decltype(m_maxHeight)>::max()),
+    m_bgraU8(false),
     m_state(),
     m_stateArray(),
     m_stateSizeInBytes(0) {
@@ -68,6 +69,7 @@ void NVEncFilterNvvfxEffect::close() {
 #endif
     AddMessage(RGY_LOG_DEBUG, _T("Close src scp conversion filter.\n"));
     m_srcCrop.reset();
+    m_srcCrop2.reset();
     AddMessage(RGY_LOG_DEBUG, _T("Close dst scp conversion filter.\n"));
     m_dstCrop.reset();
 }
@@ -178,6 +180,28 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
     if (err != RGY_ERR_NONE) {
         return err;
     }
+    // VFX SDK 1.2+ expects RGBA U8 interleaved buffers for VideoSuperRes,
+    // while pre-1.2 runtimes (0.7.x) only accept the legacy BGR F32 planar
+    // layout. Pick the buffer format by the loaded runtime version so that
+    // behavior on older runtimes stays identical to the legacy format.
+    {
+        uint32_t vfxVersion = 0;
+        if (err_to_rgy(NvVFX_GetVersion(&vfxVersion)) == RGY_ERR_NONE
+            && vfxVersion >= ((1u << 24) | (2u << 16))) {
+            AddMessage(RGY_LOG_DEBUG, _T("nvvfx runtime version %d.%d: using RGBA U8 buffers.\n"),
+                (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
+        } else {
+            m_bgraU8 = false;
+            AddMessage(RGY_LOG_WARN, _T("nvvfx runtime version %d.%d does not support RGBA U8 buffers (requires 1.2+), using legacy BGR F32 planar buffers.\n"),
+                (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
+            if (auto prmVsr = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(pParam.get());
+                prmVsr != nullptr && prmVsr->nvvfxVideoSuperRes.quality >= 8) {
+                AddMessage(RGY_LOG_ERROR, _T("quality 8-19 requires VFX SDK 1.2 or later, but the loaded nvvfx runtime is %d.%d. Please install or update the NVIDIA Video Effects runtime, or use quality 0-4.\n"),
+                    (vfxVersion >> 24) & 0xff, (vfxVersion >> 16) & 0xff);
+                return RGY_ERR_UNSUPPORTED;
+            }
+        }
+    }
     if (false) {
         uint32_t maxInputWidth = 0;
         err = err_to_rgy(NvVFX_GetU32(m_effect.get(), NVVFX_MAX_INPUT_WIDTH, &maxInputWidth));
@@ -224,8 +248,13 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
         // そうしないと128で割り切れないwidthの場合にエラーが出る
         AddMessage(RGY_LOG_DEBUG, _T("Create nvvfx input image %dx%d.\n"), pParam->frameIn.width, pParam->frameIn.height);
         m_srcImg = std::make_unique<NvCVImage>();
-        err = err_to_rgy(NvCVImage_Alloc(m_srcImg.get(), pParam->frameIn.width, pParam->frameIn.height,
-            NVCV_BGR, NVCV_F32, NVCV_PLANAR, NVCV_GPU, 1));
+        if (m_bgraU8) {
+            err = err_to_rgy(NvCVImage_Alloc(m_srcImg.get(), pParam->frameIn.width, pParam->frameIn.height,
+                NVCV_RGBA, NVCV_U8, NVCV_INTERLEAVED, NVCV_GPU, 1));
+        } else {
+            err = err_to_rgy(NvCVImage_Alloc(m_srcImg.get(), pParam->frameIn.width, pParam->frameIn.height,
+                NVCV_BGR, NVCV_F32, NVCV_PLANAR, NVCV_GPU, 1));
+        }
         if (err != RGY_ERR_NONE) {
             AddMessage(RGY_LOG_ERROR, _T("Failed to allocate nvvfx input image %dx%d: %s.\n"),
                 pParam->frameIn.width, pParam->frameIn.height, get_err_mes(err));
@@ -246,8 +275,13 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
         // そうしないと128で割り切れないwidthの場合にエラーが出る
         AddMessage(RGY_LOG_DEBUG, _T("Create nvvfx output image %dx%d.\n"), pParam->frameOut.width, pParam->frameOut.height);
         m_dstImg = std::make_unique<NvCVImage>();
-        err = err_to_rgy(NvCVImage_Alloc(m_dstImg.get(), pParam->frameOut.width, pParam->frameOut.height,
-            NVCV_BGR, NVCV_F32, NVCV_PLANAR, NVCV_GPU, 1));
+        if (m_bgraU8) {
+            err = err_to_rgy(NvCVImage_Alloc(m_dstImg.get(), pParam->frameOut.width, pParam->frameOut.height,
+                NVCV_RGBA, NVCV_U8, NVCV_INTERLEAVED, NVCV_GPU, 1));
+        } else {
+            err = err_to_rgy(NvCVImage_Alloc(m_dstImg.get(), pParam->frameOut.width, pParam->frameOut.height,
+                NVCV_BGR, NVCV_F32, NVCV_PLANAR, NVCV_GPU, 1));
+        }
         if (err != RGY_ERR_NONE) {
             AddMessage(RGY_LOG_ERROR, _T("Failed to allocate nvvfx output image %dx%d: %s.\n"),
                 pParam->frameOut.width, pParam->frameOut.height, get_err_mes(err));
@@ -287,6 +321,28 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
         m_srcCrop = std::move(filter);
         AddMessage(RGY_LOG_DEBUG, _T("created %s.\n"), m_srcCrop->GetInputMessage().c_str());
     }
+    if (m_bgraU8 && (!m_srcCrop2
+        || m_srcCrop2->GetFilterParam()->frameIn.width  != pParam->frameIn.width
+        || m_srcCrop2->GetFilterParam()->frameIn.height != pParam->frameIn.height)) {
+        // second hop: BGR F32 planar -> RGB32 (RGBA U8 packed), matching NVCV_RGBA U8 interleaved
+        AddMessage(RGY_LOG_DEBUG, _T("Create input rgb packed conversion filter.\n"));
+        unique_ptr<NVEncFilterCspCrop> filter(new NVEncFilterCspCrop());
+        shared_ptr<NVEncFilterParamCrop> paramCrop(new NVEncFilterParamCrop());
+        paramCrop->frameIn = m_srcCrop->GetFilterParam()->frameOut;
+        paramCrop->frameIn.csp = RGY_CSP_BGR_F32;
+        paramCrop->frameOut = paramCrop->frameIn;
+        paramCrop->frameOut.csp = RGY_CSP_RGB32;
+        paramCrop->baseFps = pParam->baseFps;
+        paramCrop->frameIn.mem_type = RGY_MEM_TYPE_GPU;
+        paramCrop->frameOut.mem_type = RGY_MEM_TYPE_GPU;
+        paramCrop->bOutOverwrite = false;
+        sts = filter->init(paramCrop, m_pLog);
+        if (sts != RGY_ERR_NONE) {
+            return sts;
+        }
+        m_srcCrop2 = std::move(filter);
+        AddMessage(RGY_LOG_DEBUG, _T("created %s.\n"), m_srcCrop2->GetInputMessage().c_str());
+    }
     if (!m_dstCrop
         || m_dstCrop->GetFilterParam()->frameOut.width  != pParam->frameOut.width
         || m_dstCrop->GetFilterParam()->frameOut.height != pParam->frameOut.height) {
@@ -294,7 +350,7 @@ RGY_ERR NVEncFilterNvvfxEffect::init(shared_ptr<NVEncFilterParam> pParam, shared
         unique_ptr<NVEncFilterCspCrop> filter(new NVEncFilterCspCrop());
         shared_ptr<NVEncFilterParamCrop> paramCrop(new NVEncFilterParamCrop());
         paramCrop->frameIn = pParam->frameOut;
-        paramCrop->frameIn.csp = RGY_CSP_BGR_F32;
+        paramCrop->frameIn.csp = m_bgraU8 ? RGY_CSP_RGB32 : RGY_CSP_BGR_F32;
         paramCrop->matrix = prm->vuiInfo.matrix;
         paramCrop->frameOut = pParam->frameOut;
         paramCrop->baseFps = pParam->baseFps;
@@ -402,21 +458,37 @@ RGY_ERR NVEncFilterNvvfxEffect::run_filter(const RGYFrameInfo *pInputFrame, RGYF
     }
 
     if (true) {
-        RGYFrameInfo srcImgInfo = m_srcCrop->GetFilterParam()->frameOut;
+        int cropFilterOutputNum = 0;
+        RGYFrameInfo cropInput = *pInputFrame;
+        RGYFrameInfo *outInfo[1] = { nullptr };
+        if (m_bgraU8) {
+            // first hop: NV12 -> BGR F32 planar, output to the crop filter's internal buffer
+            auto sts_filter = m_srcCrop->filter(&cropInput, outInfo, &cropFilterOutputNum, stream);
+            if (outInfo[0] == nullptr || cropFilterOutputNum != 1) {
+                AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), m_srcCrop->name().c_str());
+                return sts_filter;
+            }
+            if (sts_filter != RGY_ERR_NONE || cropFilterOutputNum != 1) {
+                AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), m_srcCrop->name().c_str());
+                return sts_filter;
+            }
+            cropInput = *outInfo[0];
+        }
+        NVEncFilterCspCrop *srcCropFinal = m_bgraU8 ? m_srcCrop2.get() : m_srcCrop.get();
+        RGYFrameInfo srcImgInfo = srcCropFinal->GetFilterParam()->frameOut;
         srcImgInfo.singleAlloc = true;
         srcImgInfo.ptr[0] = (uint8_t *)m_srcImg->pixels;
         srcImgInfo.pitch[0] = m_srcImg->pitch;
 
-        int cropFilterOutputNum = 0;
-        RGYFrameInfo *outInfo[1] = { &srcImgInfo };
-        RGYFrameInfo cropInput = *pInputFrame;
-        auto sts_filter = m_srcCrop->filter(&cropInput, (RGYFrameInfo **)&outInfo, &cropFilterOutputNum, stream);
-        if (outInfo[0] == nullptr || cropFilterOutputNum != 1) {
-            AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), m_srcCrop->name().c_str());
+        RGYFrameInfo *srcOutInfo[1] = { &srcImgInfo };
+        cropFilterOutputNum = 0;
+        auto sts_filter = srcCropFinal->filter(&cropInput, (RGYFrameInfo **)&srcOutInfo, &cropFilterOutputNum, stream);
+        if (srcOutInfo[0] == nullptr || cropFilterOutputNum != 1) {
+            AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), srcCropFinal->name().c_str());
             return sts_filter;
         }
         if (sts_filter != RGY_ERR_NONE || cropFilterOutputNum != 1) {
-            AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), m_srcCrop->name().c_str());
+            AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), srcCropFinal->name().c_str());
             return sts_filter;
         }
     } else { // デバッグ用
@@ -706,4 +778,69 @@ bool NVEncFilterNvvfxUpScaler::compareParam(const NVEncFilterParam *param) const
     auto target = dynamic_cast<const NVEncFilterParamNvvfxUpScaler *>(param);
     if (!target) return true;
     return prm->nvvfxUpscaler != target->nvvfxUpscaler;
+};
+
+tstring NVEncFilterParamNvvfxVideoSuperRes::print() const {
+    return nvvfxVideoSuperRes.print();
+}
+
+NVEncFilterNvvfxVideoSuperRes::NVEncFilterNvvfxVideoSuperRes() {
+    m_name = _T("nvvfx-videosuperres");
+    m_maxHeight = 2160;
+    // VideoSuperRes (VFX SDK 1.2+) requires RGBA/BGRA U8 interleaved buffers,
+    // unlike legacy nvvfx effects which use BGR F32 planar buffers.
+    m_bgraU8 = true;
+#if ENABLE_NVVFX
+    m_effectName = NVVFX_FX_VIDEO_SUPER_RES;
+#endif
+}
+
+NVEncFilterNvvfxVideoSuperRes::~NVEncFilterNvvfxVideoSuperRes() {
+    close();
+}
+
+RGY_ERR NVEncFilterNvvfxVideoSuperRes::checkParam(const NVEncFilterParam *param) {
+    auto prm = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(param);
+    if (!prm) {
+        AddMessage(RGY_LOG_ERROR, _T("Invalid parameter type.\n"));
+        return RGY_ERR_INVALID_PARAM;
+    }
+    // quality 0 = bicubic, 1-4 = superres (Low/Medium/High/Ultra),
+    // 8-11 = denoise, 12-15 = deblur, 16-19 = high-bitrate detail restoration (VFX SDK 1.2+).
+    // Only modes 8-15 require input=output resolution (per VFX 1.2 docs);
+    // 1-4 and 16-19 are upscalers and support resizing.
+    if (prm->nvvfxVideoSuperRes.quality < 0 || 19 < prm->nvvfxVideoSuperRes.quality
+        || (5 <= prm->nvvfxVideoSuperRes.quality && prm->nvvfxVideoSuperRes.quality < 8)) {
+        AddMessage(RGY_LOG_ERROR, _T("quality should be 0 - 19 (except 5-7).\n"));
+        return RGY_ERR_INVALID_PARAM;
+    }
+    return RGY_ERR_NONE;
+}
+
+RGY_ERR NVEncFilterNvvfxVideoSuperRes::setParam(const NVEncFilterParam *param) {
+#if !ENABLE_NVVFX
+    AddMessage(RGY_LOG_ERROR, _T("nvvfx filters is not supported on x86 exec file, please use x64 exec file.\n"));
+    return RGY_ERR_UNSUPPORTED;
+#else
+    auto prm = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes*>(param);
+    if (!prm) {
+        AddMessage(RGY_LOG_ERROR, _T("Invalid parameter type.\n"));
+        return RGY_ERR_INVALID_PARAM;
+    }
+    auto err = err_to_rgy(NvVFX_SetU32(m_effect.get(), NVVFX_QUALITY_LEVEL, prm->nvvfxVideoSuperRes.quality));
+    if (err != RGY_ERR_NONE) {
+        AddMessage(RGY_LOG_ERROR, _T("Failed to set parameter %s to %d: %s.\n"), NVVFX_QUALITY_LEVEL, prm->nvvfxVideoSuperRes.quality, get_err_mes(err));
+        return RGY_ERR_INVALID_PARAM;
+    }
+    return RGY_ERR_NONE;
+#endif
+}
+
+bool NVEncFilterNvvfxVideoSuperRes::compareParam(const NVEncFilterParam *param) const {
+    if (!m_param) return true;
+    auto prm = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes *>(m_param.get());
+    if (!prm) return true;
+    auto target = dynamic_cast<const NVEncFilterParamNvvfxVideoSuperRes *>(param);
+    if (!target) return true;
+    return prm->nvvfxVideoSuperRes != target->nvvfxVideoSuperRes;
 };

--- a/NVEncCore/NVEncFilterNvvfx.h
+++ b/NVEncCore/NVEncFilterNvvfx.h
@@ -39,6 +39,16 @@
 #pragma warning (pop)
 
 using unique_nvvfx_handle = std::unique_ptr<std::remove_pointer<NvVFX_Handle>::type, decltype(&NvVFX_DestroyEffect)>;
+
+// VideoSuperRes was introduced in VFX SDK 1.2.0.0 (the old "SuperRes" effect
+// is no longer implemented in the runtime), so these selectors are not
+// available in the bundled (older) nvVideoEffects.h.
+#ifndef NVVFX_FX_VIDEO_SUPER_RES
+#define NVVFX_FX_VIDEO_SUPER_RES "VideoSuperRes"
+#endif
+#ifndef NVVFX_QUALITY_LEVEL
+#define NVVFX_QUALITY_LEVEL "QualityLevel"
+#endif
 #endif
 
 class NVEncFilterNvvfxEffect : public NVEncFilter {
@@ -64,7 +74,11 @@ protected:
     int m_maxWidth;
     int m_maxHeight;
     std::unique_ptr<NVEncFilterCspCrop> m_srcCrop;
+    std::unique_ptr<NVEncFilterCspCrop> m_srcCrop2;
     std::unique_ptr<NVEncFilterCspCrop> m_dstCrop;
+    // true for effects requiring RGBA U8 interleaved buffers (VideoSuperRes),
+    // false for legacy BGR F32 planar buffers (denoise, superres, upscale)
+    bool m_bgraU8;
     std::unique_ptr<CUMemBuf> m_state;
     std::array<void *, 1> m_stateArray;
     uint32_t m_stateSizeInBytes;
@@ -111,6 +125,14 @@ public:
     virtual tstring print() const override;
 };
 
+class NVEncFilterParamNvvfxVideoSuperRes : public NVEncFilterParamNvvfx {
+public:
+    VppNvvfxVideoSuperRes nvvfxVideoSuperRes;
+    NVEncFilterParamNvvfxVideoSuperRes() : nvvfxVideoSuperRes() {};
+    virtual ~NVEncFilterParamNvvfxVideoSuperRes() {};
+    virtual tstring print() const override;
+};
+
 class NVEncFilterNvvfxDenoise : public NVEncFilterNvvfxEffect {
 public:
     NVEncFilterNvvfxDenoise();
@@ -145,6 +167,16 @@ class NVEncFilterNvvfxUpScaler : public NVEncFilterNvvfxEffect {
 public:
     NVEncFilterNvvfxUpScaler();
     virtual ~NVEncFilterNvvfxUpScaler();
+protected:
+    virtual RGY_ERR checkParam(const NVEncFilterParam *param) override;
+    virtual RGY_ERR setParam(const NVEncFilterParam *param) override;
+    virtual bool compareParam(const NVEncFilterParam *param) const override;
+};
+
+class NVEncFilterNvvfxVideoSuperRes : public NVEncFilterNvvfxEffect {
+public:
+    NVEncFilterNvvfxVideoSuperRes();
+    virtual ~NVEncFilterNvvfxVideoSuperRes();
 protected:
     virtual RGY_ERR checkParam(const NVEncFilterParam *param) override;
     virtual RGY_ERR setParam(const NVEncFilterParam *param) override;

--- a/NVEncCore/NVEncFilterParam.cpp
+++ b/NVEncCore/NVEncFilterParam.cpp
@@ -142,6 +142,24 @@ tstring VppNvvfxSuperRes::print() const {
         mode, get_cx_desc(list_vpp_nvvfx_mode, mode), strength);
 }
 
+VppNvvfxVideoSuperRes::VppNvvfxVideoSuperRes() :
+    enable(false),
+    quality(FILTER_DEFAULT_NVVFX_VIDEOSUPERRES_QUALITY) {
+
+}
+
+bool VppNvvfxVideoSuperRes::operator==(const VppNvvfxVideoSuperRes &x) const {
+    return enable == x.enable
+        && quality == x.quality;
+}
+bool VppNvvfxVideoSuperRes::operator!=(const VppNvvfxVideoSuperRes &x) const {
+    return !(*this == x);
+}
+
+tstring VppNvvfxVideoSuperRes::print() const {
+    return strsprintf(_T("nvvfx-videosuperres: quality: %d"), quality);
+}
+
 VppNvvfxUpScaler::VppNvvfxUpScaler() :
     enable(false),
     strength(FILTER_DEFAULT_NVVFX_UPSCALER_STRENGTH) {
@@ -215,6 +233,7 @@ VppParam::VppParam() :
     nvvfxDenoise(),
     nvvfxArtifactReduction(),
     nvvfxSuperRes(),
+    nvvfxVideoSuperRes(),
     nvvfxUpScaler(),
     nvvfxModelDir(),
     ngxVSR(),
@@ -231,6 +250,7 @@ bool VppParam::operator==(const VppParam &x) const {
            nvvfxDenoise == x.nvvfxDenoise
         && nvvfxArtifactReduction == x.nvvfxArtifactReduction
         && nvvfxSuperRes == x.nvvfxSuperRes
+        && nvvfxVideoSuperRes == x.nvvfxVideoSuperRes
         && nvvfxUpScaler == x.nvvfxUpScaler
         && nvvfxModelDir == x.nvvfxModelDir;
 
@@ -325,6 +345,15 @@ int parse_one_vppnv_option(const TCHAR* option_name, const TCHAR* strInput[], in
                 if (param_arg == _T("superres-strength")) {
                     try {
                         vppnv->nvvfxSuperRes.strength = std::stof(param_val);
+                    } catch (...) {
+                        print_cmd_error_invalid_value(tstring(option_name) + _T(" ") + param_arg + _T("="), param_val);
+                        return 1;
+                    }
+                    continue;
+                }
+                if (param_arg == _T("videosuperres-quality")) {
+                    try {
+                        vppnv->nvvfxVideoSuperRes.quality = std::stoi(param_val);
                     } catch (...) {
                         print_cmd_error_invalid_value(tstring(option_name) + _T(" ") + param_arg + _T("="), param_val);
                         return 1;
@@ -640,6 +669,11 @@ tstring gen_cmd(const VppParam *param, const VppParam *defaultPrm, RGY_VPP_RESIZ
         }
         if (param->nvvfxSuperRes.strength != defaultPrm->nvvfxSuperRes.strength) {
             cmd << _T(",superres-strength=") << param->nvvfxSuperRes.strength;
+        }
+    } else if (resize_algo == RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES) {
+        cmd << _T(" --vpp-resize ") << get_chr_from_value(list_vpp_resize, resize_algo);
+        if (param->nvvfxVideoSuperRes.quality != defaultPrm->nvvfxVideoSuperRes.quality) {
+            cmd << _T(",videosuperres-quality=") << param->nvvfxVideoSuperRes.quality;
         }
     }
 #endif

--- a/NVEncCore/NVEncFilterParam.h
+++ b/NVEncCore/NVEncFilterParam.h
@@ -61,6 +61,7 @@ static const int FILTER_DEFAULT_NVVFX_SUPER_RES_MODE = 1;
 static const float FILTER_DEFAULT_NVVFX_UPSCALER_STRENGTH = 0.4f;
 
 static const int FILTER_DEFAULT_NGX_VSR_QUALITY = 1;
+static const int FILTER_DEFAULT_NVVFX_VIDEOSUPERRES_QUALITY = 1;
 static const int FILTER_DEFAULT_NGX_TRUEHDR_CONTRAST = 125;
 static const int FILTER_DEFAULT_NGX_TRUEHDR_SATURATION = 75;
 static const int FILTER_DEFAULT_NGX_TRUEHDR_MIDDLE_GRAY = 44;
@@ -193,6 +194,16 @@ struct VppNvvfxUpScaler {
     tstring print() const;
 };
 
+struct VppNvvfxVideoSuperRes {
+    bool enable;
+    int quality;
+
+    VppNvvfxVideoSuperRes();
+    bool operator==(const VppNvvfxVideoSuperRes &x) const;
+    bool operator!=(const VppNvvfxVideoSuperRes &x) const;
+    tstring print() const;
+};
+
 struct VppNGXVSR {
     bool enable;
     int quality;
@@ -224,6 +235,7 @@ struct VppParam {
     VppNvvfxDenoise           nvvfxDenoise;
     VppNvvfxArtifactReduction nvvfxArtifactReduction;
     VppNvvfxSuperRes          nvvfxSuperRes;
+    VppNvvfxVideoSuperRes     nvvfxVideoSuperRes;
     VppNvvfxUpScaler          nvvfxUpScaler;
     tstring                   nvvfxModelDir;
     VppNGXVSR                 ngxVSR;

--- a/NVEncCore/NVEncFilterResize.cu
+++ b/NVEncCore/NVEncFilterResize.cu
@@ -1268,6 +1268,7 @@ NVEncFilterResize::NVEncFilterResize() :
     m_nisStages(1),
     m_nisCascadeInter(),
     m_nvvfxSuperRes(),
+    m_nvvfxVideoSuperRes(),
     m_ngxVSR(),
     m_libplaceboResample() {
     m_name = _T("resize");
@@ -1383,6 +1384,140 @@ RGY_ERR NVEncFilterResize::initNvvfxFilter(NVEncFilterParamResize *param) {
     return RGY_ERR_UNSUPPORTED;
 }
 
+RGY_ERR NVEncFilterResize::initNvvfxVideoSuperResFilter(NVEncFilterParamResize *param) {
+    const tstring filter_name = get_cx_desc(list_vpp_resize, param->interp);
+    const int videosuperres_quality = param->nvvfxVideoSuperRes->nvvfxVideoSuperRes.quality;
+    if (videosuperres_quality >= 8 && videosuperres_quality <= 15) {
+        // quality 8-15 (denoise/deblur) run at input resolution:
+        // the VFX runtime requires output resolution == input resolution for these modes.
+        // 16-19 (high-bitrate) are upscalers like 1-4 and go through the ratio search below.
+        if (param->frameIn.width != param->frameOut.width || param->frameIn.height != param->frameOut.height) {
+            AddMessage(RGY_LOG_ERROR, _T("%s quality 8-15 (denoise/deblur) do not support resizing.\n")
+                _T("Please set --output-res to the same resolution as the input.\n"), filter_name.c_str());
+            return RGY_ERR_UNSUPPORTED;
+        }
+        unique_ptr<NVEncFilterNvvfxVideoSuperRes> filter(new NVEncFilterNvvfxVideoSuperRes());
+        param->nvvfxVideoSuperRes->frameIn = param->frameIn;
+        param->nvvfxVideoSuperRes->frameOut = param->frameOut;
+        param->nvvfxVideoSuperRes->baseFps = param->baseFps;
+        param->nvvfxVideoSuperRes->frameIn.mem_type = RGY_MEM_TYPE_GPU;
+        param->nvvfxVideoSuperRes->frameOut.mem_type = RGY_MEM_TYPE_GPU;
+        param->nvvfxVideoSuperRes->bOutOverwrite = false;
+        auto sts = filter->init(param->nvvfxVideoSuperRes, m_pLog);
+        if (sts != RGY_ERR_NONE) {
+            AddMessage(RGY_LOG_WARN, _T("Failed to init nvvfx-videosuperres (%dx%d -> %dx%d): %s.\n"),
+                param->frameIn.width, param->frameIn.height, param->frameOut.width, param->frameOut.height, get_err_mes(sts));
+            return sts;
+        }
+        m_nvvfxVideoSuperRes = std::move(filter);
+        AddMessage(RGY_LOG_DEBUG, _T("created %s at same resolution (%dx%d).\n"),
+            m_nvvfxVideoSuperRes->GetInputMessage().c_str(), param->frameIn.width, param->frameIn.height);
+        return RGY_ERR_NONE;
+    }
+    const double target_scale_ratio_min = std::min(
+        param->frameOut.width / (double)param->frameIn.width,
+        param->frameOut.height / (double)param->frameIn.height);
+    const double target_scale_ratio_max = std::max(
+        param->frameOut.width / (double)param->frameIn.width,
+        param->frameOut.height / (double)param->frameIn.height);
+    if (target_scale_ratio_max < 1.0) {
+        AddMessage(RGY_LOG_ERROR, _T("%s not supported for resize ratio below 1.0.\n"), filter_name.c_str());
+        return RGY_ERR_UNSUPPORTED;
+    }
+    if (m_nvvfxVideoSuperRes
+        // 品質変更には再初期化が必要
+        && std::dynamic_pointer_cast<NVEncFilterParamResize>(m_param)->nvvfxVideoSuperRes->nvvfxVideoSuperRes.quality == param->nvvfxVideoSuperRes->nvvfxVideoSuperRes.quality
+        && m_param->frameIn.width == param->frameIn.width
+        && m_param->frameIn.height == param->frameIn.height
+        && m_param->frameOut.width == param->frameOut.width
+        && m_param->frameOut.height == param->frameOut.height) {
+        auto newParam = param->nvvfxVideoSuperRes->nvvfxVideoSuperRes;
+        auto oldParam = std::dynamic_pointer_cast<NVEncFilterParamResize>(m_param);
+        param->nvvfxVideoSuperRes = oldParam->nvvfxVideoSuperRes;
+        param->nvvfxVideoSuperRes->nvvfxVideoSuperRes = newParam;
+        auto sts = m_nvvfxVideoSuperRes->init(param->nvvfxVideoSuperRes, m_pLog);
+        if (sts != RGY_ERR_NONE) {
+            return sts;
+        }
+        return RGY_ERR_NONE;
+    }
+    static const auto nvvfx_scale_ratio = make_array<rgy_rational<int>>(
+        rgy_rational<int>(4, 3),
+        rgy_rational<int>(3, 2),
+        rgy_rational<int>(2, 1),
+        rgy_rational<int>(3, 1),
+        rgy_rational<int>(4, 1)
+    );
+    std::vector<bool> ratio_checked(nvvfx_scale_ratio.size(), false);
+    // 入力側からチェックする
+    // allow_upscale_after_nvvfx は nvvfxの処理後に拡大リサイズを許可するかどうか?
+    for (const bool allow_upscale_after_nvvfx : { false, true }) {
+        for (int iratio = 0; iratio < (int)nvvfx_scale_ratio.size(); iratio++) {
+            const auto ratio = nvvfx_scale_ratio[iratio];
+            const double ratiod = ratio.qdouble();
+            if ((param->frameIn.height * ratio.n()) % ratio.d() != 0) {
+                continue; // 割り切れない場合は使用しない
+            }
+            if (!ratio_checked[iratio]
+                && (ratiod >= ((allow_upscale_after_nvvfx) ? target_scale_ratio_min : target_scale_ratio_max) * (1.0 - 1e-3)
+                 || ratio == nvvfx_scale_ratio.back())) {
+                ratio_checked[iratio] = true;
+                unique_ptr<NVEncFilterNvvfxVideoSuperRes> filter(new NVEncFilterNvvfxVideoSuperRes());
+                param->nvvfxVideoSuperRes->frameIn = param->frameIn;
+                param->nvvfxVideoSuperRes->frameOut = param->frameIn;
+                param->nvvfxVideoSuperRes->frameOut.width = param->frameIn.width * ratio.n() / ratio.d();
+                param->nvvfxVideoSuperRes->frameOut.height = param->frameIn.height * ratio.n() / ratio.d();
+                param->nvvfxVideoSuperRes->baseFps = param->baseFps;
+                param->nvvfxVideoSuperRes->frameIn.mem_type = RGY_MEM_TYPE_GPU;
+                param->nvvfxVideoSuperRes->frameOut.mem_type = RGY_MEM_TYPE_GPU;
+                param->nvvfxVideoSuperRes->bOutOverwrite = false;
+                auto sts = filter->init(param->nvvfxVideoSuperRes, m_pLog);
+                if (sts == RGY_ERR_NONE) {
+                    m_nvvfxVideoSuperRes = std::move(filter);
+                    AddMessage(RGY_LOG_DEBUG, _T("created %s with ratio %.1f (%dx%d -> %dx%d).\n"), m_nvvfxVideoSuperRes->GetInputMessage().c_str(), ratio.qdouble(),
+                        param->frameIn.width, param->frameIn.height, param->nvvfxVideoSuperRes->frameOut.width, param->nvvfxVideoSuperRes->frameOut.height);
+                    return RGY_ERR_NONE;
+                }
+                AddMessage(RGY_LOG_WARN, _T("Failed to init nvvfx-videosuperres with ratio %.1f (%dx%d -> %dx%d), retrying with other ratios...\n"), ratio.qdouble(),
+                    param->frameIn.width, param->frameIn.height, param->nvvfxVideoSuperRes->frameOut.width, param->nvvfxVideoSuperRes->frameOut.height);
+            }
+        }
+    }
+    // 出力側からチェックする(倍率は逆順にチェック)
+    for (int iratio = (int)nvvfx_scale_ratio.size() - 1; iratio >= 0; iratio--) {
+        const auto ratio = nvvfx_scale_ratio[iratio];
+        if ((param->frameOut.width * ratio.d()) % ratio.n() != 0 || (param->frameOut.height * ratio.d()) % ratio.n() != 0) {
+            continue; // 割り切れない場合は使用しない
+        }
+        const int inWidth = param->frameOut.width * ratio.d() / ratio.n();
+        const int inHeight = param->frameOut.height * ratio.d() / ratio.n();
+        if (inWidth * inHeight < param->frameIn.width * param->frameIn.height) {
+            continue; // 入力サイズが小さい場合は使用しない
+        }
+        unique_ptr<NVEncFilterNvvfxVideoSuperRes> filter(new NVEncFilterNvvfxVideoSuperRes());
+        param->nvvfxVideoSuperRes->frameIn = param->frameOut;
+        param->nvvfxVideoSuperRes->frameIn.width = inWidth;
+        param->nvvfxVideoSuperRes->frameIn.height = inHeight;
+        param->nvvfxVideoSuperRes->frameOut = param->frameOut;
+        param->nvvfxVideoSuperRes->baseFps = param->baseFps;
+        param->nvvfxVideoSuperRes->frameIn.mem_type = RGY_MEM_TYPE_GPU;
+        param->nvvfxVideoSuperRes->frameOut.mem_type = RGY_MEM_TYPE_GPU;
+        param->nvvfxVideoSuperRes->bOutOverwrite = false;
+        auto sts = filter->init(param->nvvfxVideoSuperRes, m_pLog);
+        if (sts == RGY_ERR_NONE) {
+            m_nvvfxVideoSuperRes = std::move(filter);
+            AddMessage(RGY_LOG_DEBUG, _T("created %s with ratio %.1f (%dx%d -> %dx%d).\n"), m_nvvfxVideoSuperRes->GetInputMessage().c_str(), ratio.qdouble(),
+                inWidth, inHeight, param->frameOut.width, param->frameOut.height);
+            return RGY_ERR_NONE;
+        }
+        AddMessage(RGY_LOG_WARN, _T("Failed to init nvvfx-videosuperres with ratio %.1f (%dx%d -> %dx%d), retrying with other ratios...\n"), ratio.qdouble(),
+            inWidth, inHeight, param->frameOut.width, param->frameOut.height);
+    }
+
+    AddMessage(RGY_LOG_ERROR, _T("Suitable ratio for nvvfx-videosuperres not found.\n"));
+    return RGY_ERR_UNSUPPORTED;
+}
+
 RGY_ERR NVEncFilterResize::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr<RGYLog> pPrintMes) {
     RGY_ERR sts = RGY_ERR_NONE;
     m_pLog = pPrintMes;
@@ -1419,7 +1554,18 @@ RGY_ERR NVEncFilterResize::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr<
     }
 
     auto resizeInterp = pResizeParam->interp;
-    if (isNvvfxResizeFiter(pResizeParam->interp)) {
+    if (pResizeParam->interp == RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES) {
+        if (!pResizeParam->nvvfxVideoSuperRes) {
+            AddMessage(RGY_LOG_ERROR, _T("nvvfx parameter unknown.\n"));
+            return RGY_ERR_UNKNOWN;
+        }
+        sts = initNvvfxVideoSuperResFilter(pResizeParam.get());
+        if (sts != RGY_ERR_NONE) {
+            AddMessage(RGY_LOG_ERROR, _T("Failed to init nvvfx filter: %s.\n"), get_err_mes(sts));
+            return sts;
+        }
+        resizeInterp = pResizeParam->nvvfxSubAlgo;
+    } else if (isNvvfxResizeFiter(pResizeParam->interp)) {
         if (!pResizeParam->nvvfxSuperRes) {
             AddMessage(RGY_LOG_ERROR, _T("nvvfx parameter unknown.\n"));
             return RGY_ERR_UNKNOWN;
@@ -1432,7 +1578,9 @@ RGY_ERR NVEncFilterResize::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr<
         resizeInterp = pResizeParam->nvvfxSubAlgo;
     } else {
         m_nvvfxSuperRes.reset(); // 不要になったら解放
+        m_nvvfxVideoSuperRes.reset();
         pResizeParam->nvvfxSuperRes.reset();
+        pResizeParam->nvvfxVideoSuperRes.reset();
     }
     if (isNgxResizeFiter(pResizeParam->interp)) {
         if (!m_ngxVSR) {
@@ -1598,32 +1746,36 @@ RGY_ERR NVEncFilterResize::init(shared_ptr<NVEncFilterParam> pParam, shared_ptr<
     }
 
     tstring info;
-    if (m_nvvfxSuperRes) {
+    if (m_nvvfxSuperRes || m_nvvfxVideoSuperRes) {
+        NVEncFilter *nvvfxFilter = (m_nvvfxVideoSuperRes) ? (NVEncFilter *)m_nvvfxVideoSuperRes.get() : (NVEncFilter *)m_nvvfxSuperRes.get();
+        const NVEncFilterParam *nvvfxParam = (m_nvvfxVideoSuperRes)
+            ? (const NVEncFilterParam *)pResizeParam->nvvfxVideoSuperRes.get()
+            : (const NVEncFilterParam *)pResizeParam->nvvfxSuperRes.get();
         info = strsprintf(_T("resize: %s %dx%d -> %dx%d"),
             get_chr_from_value(list_vpp_resize, pResizeParam->interp),
             pParam->frameIn.width, pParam->frameIn.height,
-            pResizeParam->nvvfxSuperRes->frameOut.width, pResizeParam->nvvfxSuperRes->frameOut.height);
+            nvvfxParam->frameOut.width, nvvfxParam->frameOut.height);
         const auto indent2 = tstring(_tcslen(_T("resize:")) + 5, _T(' '));
         const auto indent = tstring(INFO_INDENT) + indent2;
         bool firstIndent = true;
-        if (   pResizeParam->nvvfxSuperRes->frameIn.width != pParam->frameIn.width
-            || pResizeParam->nvvfxSuperRes->frameIn.height != pParam->frameIn.height) {
+        if (   nvvfxParam->frameIn.width != pParam->frameIn.width
+            || nvvfxParam->frameIn.height != pParam->frameIn.height) {
             info += _T("\n") + tstring(INFO_INDENT) + tstring(_tcslen(_T("resize: ")), _T(' '));
             info += strsprintf(_T("%s %dx%d -> %dx%d"),
                 get_chr_from_value(list_vpp_resize, pResizeParam->nvvfxSubAlgo),
                 pParam->frameIn.width, pParam->frameIn.height,
-                pResizeParam->nvvfxSuperRes->frameIn.width, pResizeParam->nvvfxSuperRes->frameIn.height);
+                nvvfxParam->frameIn.width, nvvfxParam->frameIn.height);
         }
-        for (const auto& str : split(m_nvvfxSuperRes->GetInputMessage(), _T("\n"))) {
+        for (const auto& str : split(nvvfxFilter->GetInputMessage(), _T("\n"))) {
             info += _T("\n") + ((firstIndent) ? indent : indent2) + str;
             firstIndent = false;
         }
-        if (   pResizeParam->nvvfxSuperRes->frameOut.width != pParam->frameOut.width
-            || pResizeParam->nvvfxSuperRes->frameOut.height != pParam->frameOut.height) {
+        if (   nvvfxParam->frameOut.width != pParam->frameOut.width
+            || nvvfxParam->frameOut.height != pParam->frameOut.height) {
             info += _T("\n") + tstring(INFO_INDENT) + tstring(_tcslen(_T("resize: ")), _T(' '));
             info += strsprintf(_T("%s %dx%d -> %dx%d"),
                 get_chr_from_value(list_vpp_resize, pResizeParam->nvvfxSubAlgo),
-                pResizeParam->nvvfxSuperRes->frameOut.width, pResizeParam->nvvfxSuperRes->frameOut.height,
+                nvvfxParam->frameOut.width, nvvfxParam->frameOut.height,
                 pParam->frameOut.width, pParam->frameOut.height);
         }
     } else if (m_ngxVSR) {
@@ -1655,6 +1807,7 @@ NVEncFilterParamResize::NVEncFilterParamResize() :
     fsr1(),
     dpid(),
     nvvfxSuperRes(),
+    nvvfxVideoSuperRes(),
     ngxvsr(),
     libplaceboResample() {
 }
@@ -1662,16 +1815,19 @@ NVEncFilterParamResize::NVEncFilterParamResize() :
 NVEncFilterParamResize::~NVEncFilterParamResize() {};
 
 tstring NVEncFilterParamResize::print() const {
-    if (nvvfxSuperRes) {
+    if (nvvfxSuperRes || nvvfxVideoSuperRes) {
+        const NVEncFilterParam *nvvfxParam = (nvvfxVideoSuperRes)
+            ? (const NVEncFilterParam *)nvvfxVideoSuperRes.get()
+            : (const NVEncFilterParam *)nvvfxSuperRes.get();
         auto str = strsprintf(_T("resize: %s %dx%d -> %dx%d"),
             get_chr_from_value(list_vpp_resize, interp),
             frameIn.width, frameIn.height,
-            nvvfxSuperRes->frameOut.width, nvvfxSuperRes->frameOut.height);
-        if (   nvvfxSuperRes->frameOut.width != frameOut.width
-            || nvvfxSuperRes->frameOut.height != frameOut.height) {
+            nvvfxParam->frameOut.width, nvvfxParam->frameOut.height);
+        if (   nvvfxParam->frameOut.width != frameOut.width
+            || nvvfxParam->frameOut.height != frameOut.height) {
             str += strsprintf(_T("\n                       %s %dx%d -> %dx%d"),
                 get_chr_from_value(list_vpp_resize, nvvfxSubAlgo),
-                nvvfxSuperRes->frameOut.width, nvvfxSuperRes->frameOut.height,
+                nvvfxParam->frameOut.width, nvvfxParam->frameOut.height,
                 frameOut.width, frameOut.height);
         }
         return str;
@@ -1721,27 +1877,31 @@ RGY_ERR NVEncFilterResize::run_filter(const RGYFrameInfo *pInputFrame, RGYFrameI
         return RGY_ERR_INVALID_PARAM;
     }
 
-    auto resizeInterp = (m_nvvfxSuperRes) ? pResizeParam->nvvfxSubAlgo : pResizeParam->interp;
-    if (m_nvvfxSuperRes) {
+    auto resizeInterp = (m_nvvfxSuperRes || m_nvvfxVideoSuperRes) ? pResizeParam->nvvfxSubAlgo : pResizeParam->interp;
+    if (m_nvvfxSuperRes || m_nvvfxVideoSuperRes) {
+        NVEncFilter *nvvfxFilter = (m_nvvfxVideoSuperRes) ? (NVEncFilter *)m_nvvfxVideoSuperRes.get() : (NVEncFilter *)m_nvvfxSuperRes.get();
+        const NVEncFilterParam *nvvfxParam = (m_nvvfxVideoSuperRes)
+            ? (const NVEncFilterParam *)pResizeParam->nvvfxVideoSuperRes.get()
+            : (const NVEncFilterParam *)pResizeParam->nvvfxSuperRes.get();
         // 入力フレームの解像度が一致している場合は、先にnvvfxSuperresを適用する
-        if (pResizeParam->nvvfxSuperRes->frameIn.width  == pInputFrame->width
-         && pResizeParam->nvvfxSuperRes->frameIn.height == pInputFrame->height) {
+        if (nvvfxParam->frameIn.width  == pInputFrame->width
+         && nvvfxParam->frameIn.height == pInputFrame->height) {
             int nvvfxOutputNum = 0;
             RGYFrameInfo *outInfo[1] = { 0 };
             RGYFrameInfo inputFrame = *pInputFrame;
-            auto sts_filter = m_nvvfxSuperRes->filter(&inputFrame, (RGYFrameInfo **)&outInfo, &nvvfxOutputNum, stream);
+            auto sts_filter = nvvfxFilter->filter(&inputFrame, (RGYFrameInfo **)&outInfo, &nvvfxOutputNum, stream);
             if (outInfo[0] == nullptr || nvvfxOutputNum != 1) {
-                AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), m_nvvfxSuperRes->name().c_str());
+                AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), nvvfxFilter->name().c_str());
                 return sts_filter;
             }
             if (sts_filter != RGY_ERR_NONE || nvvfxOutputNum != 1) {
-                AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), m_nvvfxSuperRes->name().c_str());
+                AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), nvvfxFilter->name().c_str());
                 return sts_filter;
             }
             pInputFrame = outInfo[0];
         } else {
-            ppOutputFrames[0]->width = pResizeParam->nvvfxSuperRes->frameIn.width;
-            ppOutputFrames[0]->height = pResizeParam->nvvfxSuperRes->frameIn.height;
+            ppOutputFrames[0]->width = nvvfxParam->frameIn.width;
+            ppOutputFrames[0]->height = nvvfxParam->frameIn.height;
         }
     } else if (m_ngxVSR || m_libplaceboResample) {
         RGYFrameInfo inputFrame = *pInputFrame;
@@ -1855,22 +2015,24 @@ RGY_ERR NVEncFilterResize::run_filter(const RGYFrameInfo *pInputFrame, RGYFrameI
                 return sts;
             }
         }
-        if (m_nvvfxSuperRes
-            && pResizeParam->frameOut.width  != ppOutputFrames[0]->width
-            && pResizeParam->frameOut.height != ppOutputFrames[0]->height) {
-            int nvvfxOutputNum = 0;
-            RGYFrameInfo *outInfo[1] = { 0 };
-            RGYFrameInfo inputFrame = *ppOutputFrames[0];
-            auto sts_filter = m_nvvfxSuperRes->filter(&inputFrame, (RGYFrameInfo **)&outInfo, &nvvfxOutputNum, stream);
-            if (outInfo[0] == nullptr || nvvfxOutputNum != 1) {
-                AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), m_nvvfxSuperRes->name().c_str());
-                return sts_filter;
+        if (m_nvvfxSuperRes || m_nvvfxVideoSuperRes) {
+            NVEncFilter *nvvfxFilter = (m_nvvfxVideoSuperRes) ? (NVEncFilter *)m_nvvfxVideoSuperRes.get() : (NVEncFilter *)m_nvvfxSuperRes.get();
+            if (pResizeParam->frameOut.width  != ppOutputFrames[0]->width
+                && pResizeParam->frameOut.height != ppOutputFrames[0]->height) {
+                int nvvfxOutputNum = 0;
+                RGYFrameInfo *outInfo[1] = { 0 };
+                RGYFrameInfo inputFrame = *ppOutputFrames[0];
+                auto sts_filter = nvvfxFilter->filter(&inputFrame, (RGYFrameInfo **)&outInfo, &nvvfxOutputNum, stream);
+                if (outInfo[0] == nullptr || nvvfxOutputNum != 1) {
+                    AddMessage(RGY_LOG_ERROR, _T("Unknown behavior \"%s\".\n"), nvvfxFilter->name().c_str());
+                    return sts_filter;
+                }
+                if (sts_filter != RGY_ERR_NONE || nvvfxOutputNum != 1) {
+                    AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), nvvfxFilter->name().c_str());
+                    return sts_filter;
+                }
+                ppOutputFrames[0] = outInfo[0];
             }
-            if (sts_filter != RGY_ERR_NONE || nvvfxOutputNum != 1) {
-                AddMessage(RGY_LOG_ERROR, _T("Error while running filter \"%s\".\n"), m_nvvfxSuperRes->name().c_str());
-                return sts_filter;
-            }
-            ppOutputFrames[0] = outInfo[0];
         }
     } else {
         sts = copyFrameAsync(ppOutputFrames[0], pInputFrame, stream);
@@ -1886,6 +2048,7 @@ void NVEncFilterResize::close() {
     m_frameBuf.clear();
     m_ngxVSR.reset();
     m_nvvfxSuperRes.reset();
+    m_nvvfxVideoSuperRes.reset();
     m_libplaceboResample.reset();
     m_weightSpline.reset();
     m_weightSplineAlgo = RGY_VPP_RESIZE_UNKNOWN;

--- a/NVEncCore/NVEncFilterResize.cu
+++ b/NVEncCore/NVEncFilterResize.cu
@@ -2018,7 +2018,7 @@ RGY_ERR NVEncFilterResize::run_filter(const RGYFrameInfo *pInputFrame, RGYFrameI
         if (m_nvvfxSuperRes || m_nvvfxVideoSuperRes) {
             NVEncFilter *nvvfxFilter = (m_nvvfxVideoSuperRes) ? (NVEncFilter *)m_nvvfxVideoSuperRes.get() : (NVEncFilter *)m_nvvfxSuperRes.get();
             if (pResizeParam->frameOut.width  != ppOutputFrames[0]->width
-                && pResizeParam->frameOut.height != ppOutputFrames[0]->height) {
+                || pResizeParam->frameOut.height != ppOutputFrames[0]->height) {
                 int nvvfxOutputNum = 0;
                 RGYFrameInfo *outInfo[1] = { 0 };
                 RGYFrameInfo inputFrame = *ppOutputFrames[0];

--- a/NVEncCore/rgy_cmd.cpp
+++ b/NVEncCore/rgy_cmd.cpp
@@ -17551,8 +17551,8 @@ tstring gen_cmd_help_vpp() {
                 _T("      superres-strength=<float>\n")
                 _T("        strength for nvvfx-superres (0.0 - 1.0, default = 0.4)\n")
                 _T("      videosuperres-quality=<int>\n")
-                _T("        quality for nvvfx-videosuperres (0 - 19, except 5-7, default = 1)\n")
-                _T("        0 = bicubic, 1-4 = superres (Low/Medium/High/Ultra), 8-11 = denoise,\n")
+                _T("        quality for nvvfx-videosuperres (1 - 19, except 5-7, default = 1)\n")
+                _T("        1-4 = superres (Low/Medium/High/Ultra), 8-11 = denoise,\n")
                 _T("        12-15 = deblur, 16-19 = high-bitrate detail restoration (VFX SDK 1.2+)\n")
                 _T("        modes 8-15 do not resize: use --output-res with the same resolution as input\n"));
 #endif

--- a/NVEncCore/rgy_cmd.cpp
+++ b/NVEncCore/rgy_cmd.cpp
@@ -17549,7 +17549,12 @@ tstring gen_cmd_help_vpp() {
                 _T("        mode for nvvfx-superres     0 ... conservative\n")
                 _T("                                    1 ... aggressive (default)\n")
                 _T("      superres-strength=<float>\n")
-                _T("        strength for nvvfx-superres (0.0 - 1.0, default = 0.4)\n"));
+                _T("        strength for nvvfx-superres (0.0 - 1.0, default = 0.4)\n")
+                _T("      videosuperres-quality=<int>\n")
+                _T("        quality for nvvfx-videosuperres (0 - 19, except 5-7, default = 1)\n")
+                _T("        0 = bicubic, 1-4 = superres (Low/Medium/High/Ultra), 8-11 = denoise,\n")
+                _T("        12-15 = deblur, 16-19 = high-bitrate detail restoration (VFX SDK 1.2+)\n")
+                _T("        modes 8-15 do not resize: use --output-res with the same resolution as input\n"));
 #endif
 #if ENABLE_NVSDKNGX
             str += strsprintf(_T("\n")

--- a/NVEncCore/rgy_prm.h
+++ b/NVEncCore/rgy_prm.h
@@ -926,6 +926,7 @@ enum RGY_VPP_RESIZE_ALGO {
 #endif
 #if (ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO)) || CUFILTERS || CLFILTERS_AUF
     RGY_VPP_RESIZE_NVVFX_SUPER_RES,
+    RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES,
     RGY_VPP_RESIZE_NVVFX_MAX,
 #endif
 #if (ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO)) || CUFILTERS || CLFILTERS_AUF
@@ -1114,6 +1115,7 @@ const CX_DESC list_vpp_resize[] = {
 #endif
 #if ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO) || CUFILTERS || CLFILTERS_AUF
     { _T("nvvfx-superres"),  RGY_VPP_RESIZE_NVVFX_SUPER_RES },
+    { _T("nvvfx-videosuperres"), RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES },
 #endif
 #if ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO) || CUFILTERS || CLFILTERS_AUF
     { _T("ngx-vsr"),      RGY_VPP_RESIZE_NGX_VSR },
@@ -1212,6 +1214,7 @@ const CX_DESC list_vpp_resize_help[] = {
 #endif
 #if ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO) || CUFILTERS || CLFILTERS_AUF
     { _T("nvvfx-superres"),  RGY_VPP_RESIZE_NVVFX_SUPER_RES },
+    { _T("nvvfx-videosuperres"), RGY_VPP_RESIZE_NVVFX_VIDEO_SUPER_RES },
 #endif
 #if ENCODER_NVENC && (!defined(_M_IX86) || FOR_AUO) || CUFILTERS || CLFILTERS_AUF
     { _T("ngx-vsr"),      RGY_VPP_RESIZE_NGX_VSR },
@@ -1262,7 +1265,7 @@ const CX_DESC list_vpp_resize_help[] = {
 };
 
 static const char *paramsResizeLibPlacebo[] = { "algo", "pl-radius", "pl-clamp", "pl-taper", "pl-blur", "pl-antiring"/*, "pl-cplace"*/ };
-static const char *paramsResizeNVEnc[] = { "superres-mode", "superres-strength", "vsr-quality" };
+static const char *paramsResizeNVEnc[] = { "superres-mode", "superres-strength", "videosuperres-quality", "vsr-quality" };
 static const char *paramsResizeQSVEnc[] = { "superres-mode", "superres-algo" };
 static const char *paramsResizeFsr1[] = { "sharpness" };
 static const char *paramsResizeNis[]      = { "cascade", "sharpness", "hdr", "opt" };


### PR DESCRIPTION
## Summary
Adds a new resize algorithm `nvvfx-videosuperres` using the `VideoSuperRes` effect
introduced in NVIDIA MAXINE VideoEffects SDK 1.2 (in SDK 1.0/1.1 the same feature
was named `SuperRes`).

- New parameter `videosuperres-quality=<int>` (1 - 19, except 5 - 7, default = 1):
  - 1 - 4 = superres (Low / Medium / High / Ultra)
  - 8 - 11 = denoise
  - 12 - 15 = deblur
  - 16 - 19 = high-bitrate detail restoration (SDK 1.2 or later)
- Modes 8 - 15 (denoise/deblur) do not resize the frame. The resize filter is
  created even when no resize is requested, and an explicit `--output-res`
  matching the input resolution is required. Modes 1 - 4 and 16 - 19 are
  upscalers and follow the normal resize rules (intermediate ratio search like
  `nvvfx-superres`).
- SDK 1.2 requires RGBA/BGRA U8 interleaved buffers for this effect. On older
  runtimes the filter falls back to the legacy BGR F32 planar buffers and warns.
- Unlike the NGX path, the VFX runtime's input size limits apply to this filter.
- Help text and docs updated (`NVEncC_Options.en.md` / `.ja.md` / `.zh-cn.md`).

## Design note
SDK 1.2 renamed SuperResolution to VideoSuperResolution and changed both the
parameter semantics (quality levels replacing mode/strength) and the required
buffer format (RGBA8). I therefore added a separate `nvvfx-videosuperres`
algorithm instead of extending `nvvfx-superres` with runtime version detection,
so users on SDK 1.0/1.1 are unaffected. If you would rather have a single
`nvvfx-superres` algorithm that switches on the SDK version, I'm happy to
rework it that way.

## Testing
- Built with VS2022 + CUDA, tested on RTX 2080 (Turing) with VFX SDK 1.2.0.0.
- Verified: quality 1 - 4 upscaling, 8 - 15 same-res runs with explicit
  `--output-res`, 16 - 19 upscaling; same-res mode without `--output-res`
  correctly errors out.

## Notes
Related PR: ngx-vsr quality 8 - 19 support (the same SDK 1.2 dll also exposes
these modes through the NGX path)

## Runtime / SDK

- Documentation: [Video Super Resolution — VFX SDK User Guide](https://docs.nvidia.com/maxine/vfx/latest/Filters/VideoSuperResolution.html)
- Download: [NGC — Video Super Resolution collection](https://catalog.ngc.nvidia.com/orgs/nvidia/maxine/collections/nvvfxvideosuperres)

Install the [Video Effects SDK Core](https://catalog.ngc.nvidia.com/orgs/nvidia/maxine/resources/vfx_sdk_core/-),
then run `install_feature.ps1` with the feature name `nvvfxvideosuperres`.
Per the SDK docs, the effect's GPU buffers are BGRA/RGBA interleaved 8-bit
(what the filter uses on SDK 1.2+ runtimes), and the suggested minimum input
resolution is 360p.
